### PR TITLE
netmaker upgrade

### DIFF
--- a/vars/netmaker.yaml
+++ b/vars/netmaker.yaml
@@ -4,7 +4,7 @@
 # Base variables
 netmaker_base_domain: "netmaker.stechsolutions.ca"
 netmaker_ee: false
-netmaker_version: "v0.20.0"
+netmaker_version: "v0.20.1"
 netmaker_directory: "/home/{{ default_user }}/netmaker"
 netclient_directory: "/home/{{ default_user }}/netclient"
 


### PR DESCRIPTION
Upgrade netmaker version to v0.20.1

The enterprise features still seem to not be working. Sticking with `netmaker_ee: false` for now