### PR TITLE
Update ZFS backup dataset mount and key location

### DIFF
--- a/inventory/host_vars/pbs.home.stechsolutions.ca.yaml
+++ b/inventory/host_vars/pbs.home.stechsolutions.ca.yaml
@@ -78,12 +78,12 @@ fileserver_zfs_pools:
           - name: "/dev/disk/by-id/ata-WDC_WD10PURX-64D85Y0_WD-WCC4J7DA678L"
     datasets:
       - name: backup/backup
-        mount_point: none # This dataset is not mounted directly, but used for backups
+        mount_point: /mnt/zfs/backup  # Main backup dataset. Mounted so it auto loads encryption keys
         quota: 500G
-        canmount: "noauto"
+        canmount: "on"
         encryption: true
         encryption_passphrase: "{{ secret_zfs_datasets_encryption['backup/backup'].passphrase }}"
-        encryption_keylocation: "file:///home/{{ default_user }}/.zfs_backup.key"
+        encryption_keylocation: "file:///etc/zfs/keys/backup.key"
       # This is a small dataset to allow the healthcheck script to run on the pbs host
       - name: backup/scratch
         mount_point: /mnt/zfs/scratch

--- a/roles/fileserver/defaults/main.yaml
+++ b/roles/fileserver/defaults/main.yaml
@@ -3,6 +3,8 @@
 
 fileserver_zfs_path: "/usr/sbin/zfs"
 
+fileserver_zfs_keylocation_path: "/etc/zfs/keys"
+
 fileserver_zfs_commands:
   - "{{ fileserver_zfs_path }} send *"
   - "{{ fileserver_zfs_path }} receive *"

--- a/roles/fileserver/tasks/setup_zfs.yaml
+++ b/roles/fileserver/tasks/setup_zfs.yaml
@@ -28,3 +28,11 @@
         state: present
         validation: required
       become: true
+
+    # Ensure the ZFS key location directory exists
+    - name: Ensure the ZFS key location directory exists
+      ansible.builtin.file:
+        path: "{{ fileserver_zfs_keylocation_path }}"
+        state: directory
+        mode: '0700'
+      become: true


### PR DESCRIPTION
Changed the backup dataset to mount at /mnt/zfs/backup and updated its key location to /etc/zfs/keys/backup.key. Added a default for the ZFS key location path and a task to ensure the key directory exists with secure permissions.

This ensures the dataset key is loaded automatically on reboots.