### PR TITLE
Fix pre-commit hook to only check staged vault files

### DIFF
--- a/git-init.sh
+++ b/git-init.sh
@@ -9,10 +9,9 @@ rm .git/hooks/pre-commit
 cat <<'EOT' >> .git/hooks/pre-commit
 #!/bin/sh
 # Ensure any vault files are encrypted before allowing a commit.
-# Checks both the legacy `vault/` directory and per-inventory vaults under `vaults/*/vault.yaml`.
-for file in vault/*.yaml vaults/*/vault.yaml; do
-    [ -e "$file" ] || continue
-    if ( git show :"$file" | grep -q '^\$ANSIBLE_VAULT;' ); then
+# Only checks vault files that are staged for this commit.
+for file in $(git diff --cached --name-only | grep -E '^(vault/[^/]+\.yaml|vaults/[^/]+/vault\.yaml)$'); do
+    if git show :"$file" | grep -q '^\$ANSIBLE_VAULT;'; then
         echo "Vault Encrypted. Safe to commit."
     else
         echo "Vault not encrypted! Run 'ansible-vault encrypt \"$file\"' and try again."


### PR DESCRIPTION
Previously the hook globbed vault files on disk and blocked commits whenever any vault existed locally unencrypted, even if it wasn't staged. Switch to git diff --cached so only staged vault files are checked.