### PR TITLE
Add unrar to storage VM via split group/host package variables

### DIFF
--- a/inventories/client_welca/group_vars/proxmox_nodes.yaml
+++ b/inventories/client_welca/group_vars/proxmox_nodes.yaml
@@ -4,7 +4,7 @@
 ansible_become_password: "{{ secret_become_pass }}"
 
 # The proxmox nodes need sudo to be installed
-base_additional_packages:
+base_group_additional_packages:
   - "sudo"
   - "lshw"
   - "prometheus-node-exporter"

--- a/inventories/client_welca/group_vars/proxmox_vms.yaml
+++ b/inventories/client_welca/group_vars/proxmox_vms.yaml
@@ -2,7 +2,7 @@
 # group_vars for the proxmox_vms group (client_welca inventory)
 ansible_become_password: "{{ secret_become_pass }}"
 
-base_additional_packages:
+base_group_additional_packages:
   - "qemu-guest-agent"
 
 base_additional_services:

--- a/inventories/client_welca/host_vars/video.internal.welca.ca.yaml
+++ b/inventories/client_welca/host_vars/video.internal.welca.ca.yaml
@@ -4,9 +4,8 @@
 
 ansible_host: 10.150.1.6
 
-base_additional_packages:
+base_host_additional_packages:
   - nmap
-  - qemu-guest-agent
 
 # Configure the passed-through Intel I210 NIC (nic0 on PVE host, PCI 0000:02:00.0).
 # Matched by MAC address for deterministic interface naming.

--- a/inventories/home/group_vars/do_ansible.yaml
+++ b/inventories/home/group_vars/do_ansible.yaml
@@ -19,7 +19,7 @@ digitalocean_droplet_image: ubuntu-24-04-x64
 base_timezone: "UTC"
 
 # additional packages to install on the host
-base_additional_packages:
+base_group_additional_packages:
   - prometheus-node-exporter
 
 # additional services to configure on the host

--- a/inventories/home/group_vars/proxmox_nodes.yaml
+++ b/inventories/home/group_vars/proxmox_nodes.yaml
@@ -11,7 +11,7 @@ ansible_become_password: "{{ secret_become_pass }}"
 proxmox_update_known_hosts: true
 
 # The proxmox nodes need sudo to be installed
-base_additional_packages:
+base_group_additional_packages:
   - "sudo"
   - "lshw"
   - "prometheus-node-exporter"

--- a/inventories/home/group_vars/proxmox_pbs.yaml
+++ b/inventories/home/group_vars/proxmox_pbs.yaml
@@ -17,7 +17,7 @@ base_users:
       install: true
 
 # The proxmox nodes need sudo to be installed
-base_additional_packages:
+base_group_additional_packages:
   - "sudo"
   - "lshw"
   - "prometheus-node-exporter"

--- a/inventories/home/group_vars/proxmox_vms.yaml
+++ b/inventories/home/group_vars/proxmox_vms.yaml
@@ -12,7 +12,7 @@ base_users:
     dotfiles:
       install: true
 
-base_additional_packages:
+base_group_additional_packages:
   - "qemu-guest-agent"
   - prometheus-node-exporter
 

--- a/inventories/home/group_vars/rpi.yaml
+++ b/inventories/home/group_vars/rpi.yaml
@@ -4,5 +4,5 @@ ansible_become_password: "{{ secret_become_pass }}"
 
 ansible_ssh_pass: "{{ secret_become_pass }}"
 
-base_additional_packages:
+base_group_additional_packages:
   - "iw"

--- a/inventories/home/host_vars/docker-01.home.stechsolutions.ca/base.yaml
+++ b/inventories/home/host_vars/docker-01.home.stechsolutions.ca/base.yaml
@@ -1,9 +1,4 @@
 ---
-# Additional packages to be installed on this host
-# Main list is the same as proxmox_vms group vars
-# Need the nvidia drivers for GPU passthrough
-base_additional_packages:
-  - qemu-guest-agent
-  - prometheus-node-exporter
+base_host_additional_packages:
   - nvidia-driver-550
   - nvidia-utils-550

--- a/inventories/home/host_vars/storage.home.stechsolutions.ca.yaml
+++ b/inventories/home/host_vars/storage.home.stechsolutions.ca.yaml
@@ -7,6 +7,9 @@
 # Enable ZFS collector for prometheus-node-exporter
 base_node_exporter_zfs_collector: true
 
+base_host_additional_packages:
+  - unrar
+
 fileserver_setup: true
 fileserver_setup_mergerfs: false
 fileserver_setup_snapraid: false

--- a/roles/base/tasks/main.yaml
+++ b/roles/base/tasks/main.yaml
@@ -2,7 +2,8 @@
 # tasks file for base
 #
 # inputs:
-#   - base_additional_packages: list of additional packages to install
+#   - base_group_additional_packages: list of group-level additional packages to install
+#   - base_host_additional_packages: list of host-level additional packages to install
 #   - base_additional_services: list of additional services to enable and start
 #   - base_reboot_host_if_required: boolean to reboot the host if required
 #   - base_apt_upgrade_packages: if or how to upgrade apt packages
@@ -32,7 +33,7 @@
 - name: Install base packages
   ansible.builtin.apt:
     # append the list of packages to install with optional additional packages
-    name: "{{ base_packages + (base_additional_packages | default([])) }}"
+    name: "{{ base_packages + (base_group_additional_packages | default([])) + (base_host_additional_packages | default([])) }}"
     state: present
   become: true
   tags:


### PR DESCRIPTION
Installing `unrar` on the storage VM exposed a design gap: setting `base_additional_packages` in host_vars would shadow the group-level list entirely, silently
  dropping packages like `qemu-guest-agent` and `prometheus-node-exporter`.

  This PR fixes that by splitting the variable into two:
  - `base_group_additional_packages` — set in group_vars, for group-wide packages
  - `base_host_additional_packages` — set in host_vars, for host-specific packages

  The base role now combines all three: `base_packages + base_group_additional_packages + base_host_additional_packages`.

  As part of this, `docker-01` (home) and `video` (client_welca) have been cleaned up — they were previously duplicating their group's package list as a workaround.