### PR TITLE
Upgrade Profilarr from v1.1.4 to v2.0.4

### DIFF
--- a/docs/services/media.md
+++ b/docs/services/media.md
@@ -80,13 +80,12 @@ Prowlarr is configured via its web interface.
 
 ### Profilarr
 Profilarr is configured via its web interface.
-- Access the web UI and set the initial username and password (stored in Bitwarden).
-- Add the database (Dictionary/Database)
-- Connect Radarr to Profilarr via the API key.
-- Connect Sonarr to Profilarr via the API key.
+- On first run, navigate to the web UI — it redirects to `/auth/setup` to create the admin account. Store credentials in Bitwarden.
+- Link the Dictionarry database: **Settings → Databases → Add Database**.
+- Add arr instances: **Settings → Arr Instances** → add Radarr and Sonarr with their API keys.
 - Confirm Media Management settings are correct (naming, folders, etc).
-- Select the desired profiles to manage.
-    - Starting with default 1080p Efficient as a start.
+- Select the desired profiles to sync — start with the default 1080p Efficient profile.
+- Configure ntfy notifications: **Settings → Notifications → Add** → select ntfy, set topic to `media-health`, enable for failures only.
 
 ### Tautulli
 Tautulli is configured via its web interface.

--- a/inventories/home/host_vars/docker-01.home.stechsolutions.ca/docker_compose/downloader.yaml.j2
+++ b/inventories/home/host_vars/docker-01.home.stechsolutions.ca/docker_compose/downloader.yaml.j2
@@ -124,7 +124,7 @@ services:
       - "wud.tag.include=^v?\\d+\\.\\d+\\.\\d+$"
       - "wud.link.template=https://github.com/FlareSolverr/FlareSolverr/releases"
   profilarr:
-    image: santiagosayshey/profilarr:v1.1.4
+    image: ghcr.io/dictionarry-hub/profilarr:2.0.4
     networks:
       - arr_network
       - traefik
@@ -132,7 +132,9 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
+      - UMASK=022
       - TZ=America/Edmonton
+      - ORIGIN=https://profilarr.home.stechsolutions.ca
     volumes:
       - /home/{{ default_user }}/docker_mounts/downloader/profilarr:/config
     depends_on:


### PR DESCRIPTION
## Summary

| Item | v1 | v2 |
|---|---|---|
| Image | `santiagosayshey/profilarr:v1.1.4` (Docker Hub) | `ghcr.io/dictionarry-hub/profilarr:2.0.4` (GHCR) |
| Auth | None | Built-in (`/auth/setup` on first run) |
| Reverse proxy | — | `ORIGIN` env var required (CSRF protection) |
| Config format | v1 | **Not compatible with v1** — fresh setup required |

- Add `ORIGIN=https://profilarr.home.stechsolutions.ca` (required for Traefik — without it all POSTs get 403)
- Add `UMASK=022`
- Update `docs/services/media.md` with v2 first-run setup steps and ntfy `media-health` notification config

## Pre-deploy steps

Wipe the v1 config on docker-01 before applying:
```bash
ssh nelson@docker-01.home.stechsolutions.ca "rm -rf /home/nelson/docker_mounts/downloader/profilarr/*"
```

Old config is backed up via PBS if rollback is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)