### PR TITLE
Add starship prompt installation to dotfiles setup

### DIFF
--- a/roles/base/tasks/setup_dotfiles.yaml
+++ b/roles/base/tasks/setup_dotfiles.yaml
@@ -27,8 +27,15 @@
         state: present
       become: true
 
+    - name: Download starship install script
+      ansible.builtin.get_url:
+        url: https://starship.rs/install.sh
+        dest: /tmp/starship-install.sh
+        mode: "0755"
+      become: true
+
     - name: Install starship prompt
-      ansible.builtin.shell: curl -sS https://starship.rs/install.sh | sh -s -- --yes
+      ansible.builtin.command: /tmp/starship-install.sh --yes
       args:
         creates: /usr/local/bin/starship
       become: true

--- a/roles/base/tasks/setup_dotfiles.yaml
+++ b/roles/base/tasks/setup_dotfiles.yaml
@@ -27,6 +27,12 @@
         state: present
       become: true
 
+    - name: Install starship prompt
+      ansible.builtin.shell: curl -sS https://starship.rs/install.sh | sh -s -- --yes
+      args:
+        creates: /usr/local/bin/starship
+      become: true
+
     - name: Make the directory for the dotfiles
       ansible.builtin.file:
         path: "{{ dotfiles_dir }}"


### PR DESCRIPTION
## Summary

- Adds `starship` binary installation to the `base` dotfiles role
- Uses the official install script with `creates: /usr/local/bin/starship` for idempotency
- Pairs with nstoik/dotfiles#14 which adds the Starship config and switches from Powerlevel10k

Closes #89

## Test plan

- [ ] Run `ansible-playbook playbooks/hosts_configure.yaml --tags=base.dotfiles` on a host without starship — binary is installed to `/usr/local/bin/starship`
- [ ] Run again — task is skipped (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)