### PR TITLE
Add inxi to base packages, move wireguard to docker-01 host_vars

### DIFF
--- a/inventories/home/host_vars/docker-01.home.stechsolutions.ca/base.yaml
+++ b/inventories/home/host_vars/docker-01.home.stechsolutions.ca/base.yaml
@@ -2,3 +2,5 @@
 base_host_additional_packages:
   - nvidia-driver-550
   - nvidia-utils-550
+  - wireguard
+  - wireguard-tools

--- a/roles/base/defaults/main.yaml
+++ b/roles/base/defaults/main.yaml
@@ -15,11 +15,10 @@ base_reboot_host_if_required: true
 # the base packages to install
 base_packages:
   - git
+  - inxi
   - jq
   - neofetch
   - vnstat
-  - wireguard
-  - wireguard-tools
 
 # the base services to enable and start
 # eg format will include the service name, state, and optional enabled state


### PR DESCRIPTION
## Summary

- Add `inxi` to `base_packages` for disk/system information gathering when investigating or adding new disks
- Remove `wireguard` and `wireguard-tools` from default base packages — no longer universally needed since moving to Tailscale
- Move `wireguard`/`wireguard-tools` to `docker-01` `base_host_additional_packages` where they are required by qbittorrentvpn

Closes #106

## Test plan

- [x] Run `ansible-playbook playbooks/hosts_configure.yaml --tags=base.apt` on a host — `inxi` is installed, wireguard is not
- [x] Run against docker-01 — wireguard and wireguard-tools are still installed via host_vars
- [x] Confirm qbittorrentvpn continues to function on docker-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)