### PR TITLE
Add gping and trippy via generic GitHub binary installer

### DIFF
--- a/roles/base/defaults/main.yaml
+++ b/roles/base/defaults/main.yaml
@@ -16,23 +16,26 @@ base_reboot_host_if_required: true
 # Each entry requires:
 #   name: used as the archive filename in /tmp
 #   url: download URL (may reference ansible_architecture)
-#   dest: final binary path (used to check if already installed)
+#   dest: final binary path (checked on each run; reinstall triggered if missing)
 #   archive_binary: path to the binary inside the extracted archive
 base_github_binaries:
   - name: gping
     url: "https://github.com/orf/gping/releases/download/gping-v1.20.1/gping-Linux-musl-{{ 'arm64' if ansible_architecture == 'aarch64' else 'x86_64' }}.tar.gz"
     dest: /usr/local/bin/gping
     archive_binary: gping
+    capabilities: cap_net_raw+ep
   - name: trippy
     url: "https://github.com/fujiapple852/trippy/releases/download/0.13.0/trippy-0.13.0-{{ ansible_architecture }}-unknown-linux-musl.tar.gz"
     dest: /usr/local/bin/trip
     archive_binary: "trippy-0.13.0-{{ ansible_architecture }}-unknown-linux-musl/trip"
+    capabilities: cap_net_raw+ep
 
 # the base packages to install
 base_packages:
   - git
   - inxi
   - jq
+  - libcap2-bin  # required by community.general.capabilities to set/get binary capabilities (e.g. cap_net_raw for gping/trippy)
   - neofetch
   - vnstat
 

--- a/roles/base/defaults/main.yaml
+++ b/roles/base/defaults/main.yaml
@@ -12,6 +12,22 @@ base_apt_update_packages: true
 # variables for rebooting the host
 base_reboot_host_if_required: true
 
+# GitHub-released binaries to install on all hosts.
+# Each entry requires:
+#   name: used as the archive filename in /tmp
+#   url: download URL (may reference ansible_architecture)
+#   dest: final binary path (used to check if already installed)
+#   archive_binary: path to the binary inside the extracted archive
+base_github_binaries:
+  - name: gping
+    url: "https://github.com/orf/gping/releases/download/gping-v1.20.1/gping-Linux-musl-{{ 'arm64' if ansible_architecture == 'aarch64' else 'x86_64' }}.tar.gz"
+    dest: /usr/local/bin/gping
+    archive_binary: gping
+  - name: trippy
+    url: "https://github.com/fujiapple852/trippy/releases/download/0.13.0/trippy-0.13.0-{{ ansible_architecture }}-unknown-linux-musl.tar.gz"
+    dest: /usr/local/bin/trip
+    archive_binary: "trippy-0.13.0-{{ ansible_architecture }}-unknown-linux-musl/trip"
+
 # the base packages to install
 base_packages:
   - git

--- a/roles/base/defaults/main.yaml
+++ b/roles/base/defaults/main.yaml
@@ -12,22 +12,27 @@ base_apt_update_packages: true
 # variables for rebooting the host
 base_reboot_host_if_required: true
 
+# Architecture strings used in GitHub release URLs.
+# gping uses arm64 for aarch64; trippy uses the native architecture name.
+base_gping_arch: "{{ 'arm64' if ansible_facts['architecture'] == 'aarch64' else 'x86_64' }}"
+base_trippy_arch: "{{ ansible_facts['architecture'] }}"
+
 # GitHub-released binaries to install on all hosts.
 # Each entry requires:
-#   name: used as the archive filename in /tmp
-#   url: download URL (may reference ansible_architecture)
+#   name: used for the URL marker file
+#   url: download URL (may reference base_gping_arch / base_trippy_arch)
 #   dest: final binary path (checked on each run; reinstall triggered if missing)
 #   archive_binary: path to the binary inside the extracted archive
 base_github_binaries:
   - name: gping
-    url: "https://github.com/orf/gping/releases/download/gping-v1.20.1/gping-Linux-musl-{{ 'arm64' if ansible_architecture == 'aarch64' else 'x86_64' }}.tar.gz"
+    url: "https://github.com/orf/gping/releases/download/gping-v1.20.1/gping-Linux-musl-{{ base_gping_arch }}.tar.gz"
     dest: /usr/local/bin/gping
     archive_binary: gping
     capabilities: cap_net_raw+ep
   - name: trippy
-    url: "https://github.com/fujiapple852/trippy/releases/download/0.13.0/trippy-0.13.0-{{ ansible_architecture }}-unknown-linux-musl.tar.gz"
+    url: "https://github.com/fujiapple852/trippy/releases/download/0.13.0/trippy-0.13.0-{{ base_trippy_arch }}-unknown-linux-musl.tar.gz"
     dest: /usr/local/bin/trip
-    archive_binary: "trippy-0.13.0-{{ ansible_architecture }}-unknown-linux-musl/trip"
+    archive_binary: "trippy-0.13.0-{{ base_trippy_arch }}-unknown-linux-musl/trip"
     capabilities: cap_net_raw+ep
 
 # the base packages to install

--- a/roles/base/tasks/install_github_binary.yaml
+++ b/roles/base/tasks/install_github_binary.yaml
@@ -35,14 +35,14 @@
 - name: Download archive for {{ base_github_binary.name }}
   ansible.builtin.get_url:
     url: "{{ base_github_binary.url }}"
-    dest: "/tmp/{{ base_github_binary.name }}.tar.gz"
+    dest: "/tmp/{{ base_github_binary.url | basename }}"
     mode: "0644"
   become: true
   when: base_github_binary_needs_install
 
 - name: Extract archive to /tmp for {{ base_github_binary.name }}
   ansible.builtin.unarchive:
-    src: "/tmp/{{ base_github_binary.name }}.tar.gz"
+    src: "/tmp/{{ base_github_binary.url | basename }}"
     dest: /tmp
     remote_src: true
   become: true

--- a/roles/base/tasks/install_github_binary.yaml
+++ b/roles/base/tasks/install_github_binary.yaml
@@ -13,6 +13,11 @@
     path: "/usr/local/share/{{ base_github_binary.name }}.url"
   register: base_github_binary_marker_stat
 
+- name: Check dest binary exists for {{ base_github_binary.name }}
+  ansible.builtin.stat:
+    path: "{{ base_github_binary.dest }}"
+  register: base_github_binary_dest_stat
+
 - name: Read URL marker for {{ base_github_binary.name }}
   ansible.builtin.slurp:
     src: "/usr/local/share/{{ base_github_binary.name }}.url"
@@ -23,7 +28,8 @@
 - name: Set install flag for {{ base_github_binary.name }}
   ansible.builtin.set_fact:
     base_github_binary_needs_install: >-
-      {{ not base_github_binary_marker_stat.stat.exists or
+      {{ not base_github_binary_dest_stat.stat.exists or
+         not base_github_binary_marker_stat.stat.exists or
          (base_github_binary_marker_content.content | b64decode | trim) != base_github_binary.url }}
 
 - name: Download archive for {{ base_github_binary.name }}
@@ -58,3 +64,11 @@
     mode: "0644"
   become: true
   when: base_github_binary_needs_install
+
+- name: Set capabilities for {{ base_github_binary.name }}
+  community.general.capabilities:
+    path: "{{ base_github_binary.dest }}"
+    capability: "{{ base_github_binary.capabilities }}"
+    state: present
+  become: true
+  when: base_github_binary.capabilities is defined

--- a/roles/base/tasks/install_github_binary.yaml
+++ b/roles/base/tasks/install_github_binary.yaml
@@ -1,0 +1,60 @@
+---
+# Install or update a single GitHub-released binary.
+# Called from setup_github_binaries.yaml in a loop.
+#
+# inputs (via loop_var base_github_binary):
+#   - base_github_binary.name: used for archive filename and marker file
+#   - base_github_binary.url: download URL; reinstall is triggered when this changes
+#   - base_github_binary.dest: final binary path
+#   - base_github_binary.archive_binary: path to the binary inside the extracted archive
+
+- name: Check URL marker for {{ base_github_binary.name }}
+  ansible.builtin.stat:
+    path: "/usr/local/share/{{ base_github_binary.name }}.url"
+  register: base_github_binary_marker_stat
+
+- name: Read URL marker for {{ base_github_binary.name }}
+  ansible.builtin.slurp:
+    src: "/usr/local/share/{{ base_github_binary.name }}.url"
+  register: base_github_binary_marker_content
+  become: true
+  when: base_github_binary_marker_stat.stat.exists
+
+- name: Set install flag for {{ base_github_binary.name }}
+  ansible.builtin.set_fact:
+    base_github_binary_needs_install: >-
+      {{ not base_github_binary_marker_stat.stat.exists or
+         (base_github_binary_marker_content.content | b64decode | trim) != base_github_binary.url }}
+
+- name: Download archive for {{ base_github_binary.name }}
+  ansible.builtin.get_url:
+    url: "{{ base_github_binary.url }}"
+    dest: "/tmp/{{ base_github_binary.name }}.tar.gz"
+    mode: "0644"
+  become: true
+  when: base_github_binary_needs_install
+
+- name: Extract archive to /tmp for {{ base_github_binary.name }}
+  ansible.builtin.unarchive:
+    src: "/tmp/{{ base_github_binary.name }}.tar.gz"
+    dest: /tmp
+    remote_src: true
+  become: true
+  when: base_github_binary_needs_install
+
+- name: Install binary to destination for {{ base_github_binary.name }}
+  ansible.builtin.copy:
+    src: "/tmp/{{ base_github_binary.archive_binary }}"
+    dest: "{{ base_github_binary.dest }}"
+    mode: "0755"
+    remote_src: true
+  become: true
+  when: base_github_binary_needs_install
+
+- name: Write URL marker for {{ base_github_binary.name }}
+  ansible.builtin.copy:
+    content: "{{ base_github_binary.url }}"
+    dest: "/usr/local/share/{{ base_github_binary.name }}.url"
+    mode: "0644"
+  become: true
+  when: base_github_binary_needs_install

--- a/roles/base/tasks/main.yaml
+++ b/roles/base/tasks/main.yaml
@@ -40,6 +40,14 @@
     - base
     - base.apt
 
+# Install GitHub-released binaries
+- name: Install GitHub-released binaries
+  ansible.builtin.include_tasks: setup_github_binaries.yaml
+  when: ansible_facts['os_family'] == "Debian"
+  tags:
+    - base
+    - base.binaries
+
 # set the timezone
 - name: Set the timezone
   community.general.timezone:

--- a/roles/base/tasks/setup_github_binaries.yaml
+++ b/roles/base/tasks/setup_github_binaries.yaml
@@ -1,0 +1,16 @@
+---
+# Install GitHub-released binaries defined in base_github_binaries.
+# Called from main.yaml on Debian-family hosts.
+# Uses a URL marker file to detect version changes and reinstall when the URL changes.
+
+- name: Block for GitHub binary installs
+  tags:
+    - base
+    - base.binaries
+  block:
+    - name: Install GitHub binary
+      ansible.builtin.include_tasks: install_github_binary.yaml
+      loop: "{{ base_github_binaries }}"
+      loop_control:
+        loop_var: base_github_binary
+        label: "{{ base_github_binary.name }}"


### PR DESCRIPTION
## Summary

- Introduce a reusable `base_github_binaries` list in defaults — each entry specifies a `url`, `dest`, and `archive_binary` path
- New task files `setup_github_binaries.yaml` + `install_github_binary.yaml` handle download, extraction, and install generically
- Version tracking via a URL marker file at `/usr/local/share/<name>.url` — reinstall triggers automatically when the URL changes; deleting the marker forces a reinstall
- Add `gping` (graphical ping TUI) and `trippy` (traceroute/ping TUI) as the first entries
- Future binaries can be added by appending to `base_github_binaries` in defaults or overriding in host/group vars

Closes #150

## Test plan

- [x] Run `ansible-playbook playbooks/hosts_configure.yaml --tags=base.binaries` on a host — `gping` and `trip` binaries installed to `/usr/local/bin/`, marker files written to `/usr/local/share/`
- [x] Run again — all tasks skipped (idempotent)
- [x] Bump a URL in defaults, re-run — binary reinstalled, marker updated
- [x] Delete a marker file, re-run — binary reinstalled

🤖 Generated with [Claude Code](https://claude.com/claude-code)