### PR TITLE
Add docs for base.binaries tag and base_github_binaries

### DIFF
--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -12,6 +12,7 @@ ansible-playbook playbooks/hosts_configure.yaml --tags=base
 
 - `base` - Base role and all base tasks
 - `base.apt` - Configure apt package manager and install packages
+- `base.binaries` - Install GitHub-released binaries defined in `base_github_binaries`
 - `base.docker` - Configure Docker repositor
 - `base.dotfiles` - Configure dotfiles
 - `base.known_hosts` - Configure known_hosts file on the local machine

--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -12,7 +12,7 @@ ansible-playbook playbooks/hosts_configure.yaml --tags=base
 
 - `base` - Base role and all base tasks
 - `base.apt` - Configure apt package manager and install packages
-- `base.binaries` - Install GitHub-released binaries defined in `base_github_binaries`
+- `base.binaries` - Install GitHub-released binaries defined in `base_github_binaries` (Debian-family hosts only)
 - `base.docker` - Configure Docker repositor
 - `base.dotfiles` - Configure dotfiles
 - `base.known_hosts` - Configure known_hosts file on the local machine

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -12,6 +12,34 @@ Sets up the base configuration for all managed hosts: packages, users, dotfiles,
 | `base_apt_update_packages` | `true` | Run apt update before installing packages |
 | `base_packages` | `[git, jq, neofetch, ...]` | Additional packages to install |
 
+### GitHub Binary Installs
+
+Binaries not available in apt can be installed from GitHub releases via the `base_github_binaries` list. Each entry is downloaded, extracted, and installed idempotently. A URL marker file at `/usr/local/share/<name>.url` tracks the installed version — the binary is reinstalled automatically when the URL changes. Deleting the marker file forces a reinstall without changing the URL.
+
+| Variable | Default | Description |
+|---|---|---|
+| `base_github_binaries` | `[gping, trippy]` | List of GitHub-released binaries to install |
+
+Each entry in `base_github_binaries` supports:
+
+| Key | Required | Description |
+|---|---|---|
+| `name` | yes | Binary name, used for the /tmp archive filename and marker file |
+| `url` | yes | Download URL for the release archive (may reference `ansible_architecture`) |
+| `dest` | yes | Final installed binary path (e.g. `/usr/local/bin/gping`) |
+| `archive_binary` | yes | Path to the binary inside the extracted archive |
+| `capabilities` | no | Linux capability string to set on the binary (e.g. `cap_net_raw+ep`) |
+
+Example — adding a new binary:
+
+```yaml
+base_github_binaries:
+  - name: myapp
+    url: "https://github.com/org/myapp/releases/download/v1.0.0/myapp-{{ ansible_facts['architecture'] }}-linux.tar.gz"
+    dest: /usr/local/bin/myapp
+    archive_binary: myapp
+```
+
 ### User Configuration
 
 | Variable | Default | Description |

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -18,14 +18,14 @@ Binaries not available in apt can be installed from GitHub releases via the `bas
 
 | Variable | Default | Description |
 |---|---|---|
-| `base_github_binaries` | `[gping, trippy]` | List of GitHub-released binaries to install |
+| `base_github_binaries` | see `defaults/main.yaml` | List of GitHub-released binaries to install (defaults include gping and trippy) |
 
 Each entry in `base_github_binaries` supports:
 
 | Key | Required | Description |
 |---|---|---|
-| `name` | yes | Binary name, used for the /tmp archive filename and marker file |
-| `url` | yes | Download URL for the release archive (may reference `ansible_architecture`) |
+| `name` | yes | Binary name, used for the URL marker file at `/usr/local/share/<name>.url` |
+| `url` | yes | Download URL for the release archive (may reference `ansible_facts['architecture']`, `base_gping_arch`, or `base_trippy_arch`) |
 | `dest` | yes | Final installed binary path (e.g. `/usr/local/bin/gping`) |
 | `archive_binary` | yes | Path to the binary inside the extracted archive |
 | `capabilities` | no | Linux capability string to set on the binary (e.g. `cap_net_raw+ep`) |


### PR DESCRIPTION
## Summary

- Add `base.binaries` tag to `docs/TAGS.md`
- Add GitHub Binary Installs section to `roles/base/README.md` documenting `base_github_binaries` variable structure and usage

Missed in #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)