### PR TITLE
Traefik access-log management + centralized logging (Loki/Alloy, GeoIP, dashboards)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,10 @@ files/                      # Jinja2 templates and static config files
   grafana/provisioning/
     dashboards/             # Grafana dashboard provisioning config (points to dashboards_json/)
     dashboards_json/        # Auto-provisioned Grafana dashboard JSON files
-    datasources/            # Grafana datasource config (Prometheus)
+    datasources/            # Grafana datasource config (Prometheus, Loki)
   homepage/                 # Internal homepage (gethomepage) config — internal dashboard
   homepage_media/           # External media homepage config — public-facing at media.stechsolutions.ca
+  loki/                     # Loki server config (log aggregation; runs on docker-02)
   ntfy/                     # Ntfy notification server config
   ntfy-alertmanager/        # ntfy-alertmanager bridge config (receives from Alertmanager, sends to ntfy)
   peanut/                   # Peanut NUT web interface config
@@ -106,6 +107,11 @@ Variables follow role-name prefixes: `docker_*`, `fileserver_*`, `base_*`, `secr
 - Each inventory has an independent vault at `inventories/<name>/group_vars/all/vault.yaml` with a matching vault ID label (e.g., `home@./vault_pass.txt`)
 - Vault files are AES-256 encrypted and safe to commit; only password files (`vault_pass*.txt`) are gitignored
 
+### Monitoring & logging
+
+- **Metrics**: `prometheus-node-exporter` (apt, host-level) on every host → Prometheus on docker-02 → Grafana.
+- **Logs**: **Grafana Alloy** (host-level, installed by the base role via `base_alloy_setup`) ships log files defined in `base_alloy_log_sources` to **Loki** (a container on docker-02) → queried in Grafana via the auto-provisioned Loki datasource. Alloy is host-level (a systemd service, like node_exporter) rather than a container, so it reads logs directly and generalizes to any host type. Traefik `access.log` is the first source; it is filtered (in the Traefik static config) and rotated via the docker role's `docker_logrotate_configs`.
+
 ### Vault security
 
 A pre-commit hook (installed by `./git-init.sh`) blocks committing unencrypted vault files. Run `./git-init.sh` once after cloning to install it.
@@ -125,7 +131,7 @@ A pre-commit hook (installed by `./git-init.sh`) blocks committing unencrypted v
 
 Tags follow a `role` and `role.subtask` pattern. Key tags for `hosts_configure.yaml`:
 
-- `base`, `base.apt`, `base.dotfiles`, `base.user`, `base.geerlingguy.security`
+- `base`, `base.apt`, `base.dotfiles`, `base.user`, `base.geerlingguy.security`, `base.alloy`
 - `docker`, `docker.compose`, `docker.prune`
 - `fileserver`, `fileserver.zfs`, `fileserver.nfs-server`, `fileserver.nfs-client`, `fileserver.mergerfs`, `fileserver.snapraid`
 - `proxmox`, `proxmox.pve`, `proxmox.vm`, `proxmox.container`

--- a/docs/MANUAL_CONFIG.md
+++ b/docs/MANUAL_CONFIG.md
@@ -214,12 +214,12 @@ upscmd -u admin -p REPLACE_PASSWORD myups@localhost test.battery.start.deep
 ### Web Interface
 Access the NUT web interface (Peanut) at [peanut.home.stechsolutions.ca](https://peanut.home.stechsolutions.ca).
 
-## Prometheus & Grafana
+## Prometheus, Grafana & Loki
 
-Prometheus and Grafana are configured via Ansible. However, some additional manual steps may be needed:
+Prometheus (metrics), Loki (logs), and Grafana (visualization) are configured via Ansible. However, some additional manual steps may be needed:
 
 ### Grafana Datasources
-Check that Prometheus is configured as a datasource (should be auto-provisioned from [files/grafana/provisioning/](../files/grafana/provisioning/)).
+Check that **Prometheus** (metrics) and **Loki** (logs) are configured as datasources (both should be auto-provisioned from [files/grafana/provisioning/datasources/](../files/grafana/provisioning/datasources/)).
 
 ### Grafana Dashboards
 Dashboards in `files/grafana/provisioning/dashboards_json/` are **auto-provisioned** on deploy — no manual import needed. Current dashboards include:

--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -11,6 +11,7 @@ ansible-playbook playbooks/hosts_configure.yaml --tags=base
 ```
 
 - `base` - Base role and all base tasks
+- `base.alloy` - Install and configure Grafana Alloy log shipping agent (when `base_alloy_setup` is true)
 - `base.apt` - Configure apt package manager and install packages
 - `base.binaries` - Install GitHub-released binaries defined in `base_github_binaries` (Debian-family hosts only)
 - `base.docker` - Configure Docker repositor

--- a/files/grafana/provisioning/dashboards_json/traefik/traefik.json
+++ b/files/grafana/provisioning/dashboards_json/traefik/traefik.json
@@ -209,7 +209,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(traefik_entrypoint_requests_total{entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$interval])) by (entrypoint)",
+          "expr": "sum(rate(traefik_entrypoint_requests_total{entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$__rate_interval])) by (entrypoint)",
           "legendFormat": "{{entrypoint}}",
           "range": true,
           "refId": "A"
@@ -312,7 +312,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.3\",code=\"200\",entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$interval])) by (method) + \n sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"1.2\",code=\"200\",entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$interval])) by (method)) / 2 / \n sum(rate(traefik_entrypoint_request_duration_seconds_count{code=\"200\",entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$interval])) by (method)\n",
+          "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.3\",code=\"200\",entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$__rate_interval])) by (method) + \n sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"1.2\",code=\"200\",entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$__rate_interval])) by (method)) / 2 / \n sum(rate(traefik_entrypoint_request_duration_seconds_count{code=\"200\",entrypoint=~\"$entrypoint\",instance=~\"$instance\"}[$__rate_interval])) by (method)\n",
           "legendFormat": "{{method}}",
           "range": true,
           "refId": "A"
@@ -382,7 +382,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(traefik_service_requests_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$interval])) by (method, code)",
+          "expr": "sum(rate(traefik_service_requests_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) by (method, code)",
           "legendFormat": "{{method}}[{{code}}]",
           "range": true,
           "refId": "A"
@@ -590,7 +590,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(15,\n    label_replace(\n        sum by (service,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
           "legendFormat": "[{{code}}] on {{service}}",
           "range": true,
           "refId": "A"
@@ -699,7 +699,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "label_replace(\n  1 - (sum by (service)\n    (rate(traefik_service_request_duration_seconds_bucket{le=\"1.2\",service=~\"$service.*\",instance=~\"$instance\"}[$interval])) / sum by (service) \n    (rate(traefik_service_request_duration_seconds_count{service=~\"$service.*\",instance=~\"$instance\"}[$interval]))\n  ) > 0,\n  \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\"\n)",
+              "expr": "label_replace(\n  1 - (sum by (service)\n    (rate(traefik_service_request_duration_seconds_bucket{le=\"1.2\",service=~\"$service.*\",instance=~\"$instance\"}[$__rate_interval])) / sum by (service) \n    (rate(traefik_service_request_duration_seconds_count{service=~\"$service.*\",instance=~\"$instance\"}[$__rate_interval]))\n  ) > 0,\n  \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\"\n)",
               "legendFormat": "{{service}}",
               "range": true,
               "refId": "A"
@@ -798,7 +798,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "label_replace(\n  1 - (sum by (service)\n    (rate(traefik_service_request_duration_seconds_bucket{le=\"0.3\",service=~\"$service.*\",instance=~\"$instance\"}[$interval])) / sum by (service) \n    (rate(traefik_service_request_duration_seconds_count{service=~\"$service.*\",instance=~\"$instance\"}[$interval]))\n  ) > 0,\n  \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\"\n)",
+              "expr": "label_replace(\n  1 - (sum by (service)\n    (rate(traefik_service_request_duration_seconds_bucket{le=\"0.3\",service=~\"$service.*\",instance=~\"$instance\"}[$__rate_interval])) / sum by (service) \n    (rate(traefik_service_request_duration_seconds_count{service=~\"$service.*\",instance=~\"$instance\"}[$__rate_interval]))\n  ) > 0,\n  \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\"\n)",
               "legendFormat": "{{service}}",
               "range": true,
               "refId": "A"
@@ -919,13 +919,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code=~\"2..\",protocol=\"http\",instance=~\"$instance\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code=~\"2..\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
           "legendFormat": "{{method}}[{{code}}] on {{service}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "2xx over $interval",
+      "title": "2xx rate",
       "type": "timeseries"
     },
     {
@@ -1024,13 +1024,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code=~\"5..\",protocol=\"http\",instance=~\"$instance\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code=~\"5..\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
           "legendFormat": "{{method}}[{{code}}] on {{service}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "5xx over $interval",
+      "title": "5xx rate",
       "type": "timeseries"
     },
     {
@@ -1129,13 +1129,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code!~\"2..|5..\",protocol=\"http\",instance=~\"$instance\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code!~\"2..|5..\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
           "legendFormat": "{{method}}[{{code}}] on {{service}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Other codes over $interval",
+      "title": "Other codes rate",
       "type": "timeseries"
     },
     {
@@ -1234,7 +1234,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(15,\n    label_replace(\n        sum by (service,method) \n          (rate(traefik_service_requests_bytes_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method) \n          (rate(traefik_service_requests_bytes_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
           "legendFormat": "{{method}} on {{service}}",
           "range": true,
           "refId": "A"
@@ -1339,7 +1339,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "topk(15,\n    label_replace(\n        sum by (service,method) \n          (rate(traefik_service_responses_bytes_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method) \n          (rate(traefik_service_responses_bytes_total{service=~\"$service.*\",protocol=\"http\",instance=~\"$instance\"}[$__rate_interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^-]+-[^-]+).*\")\n)",
           "legendFormat": "{{method}} on {{service}}",
           "range": true,
           "refId": "A"
@@ -1493,61 +1493,6 @@
         "refresh": 1,
         "regex": "",
         "type": "query"
-      },
-      {
-        "auto": true,
-        "auto_count": 30,
-        "auto_min": "1m",
-        "current": {
-          "text": "$__auto",
-          "value": "$__auto"
-        },
-        "name": "interval",
-        "options": [
-          {
-            "selected": false,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "5m",
-            "value": "5m"
-          },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          },
-          {
-            "selected": false,
-            "text": "30m",
-            "value": "30m"
-          },
-          {
-            "selected": false,
-            "text": "1h",
-            "value": "1h"
-          },
-          {
-            "selected": false,
-            "text": "2h",
-            "value": "2h"
-          },
-          {
-            "selected": false,
-            "text": "4h",
-            "value": "4h"
-          },
-          {
-            "selected": false,
-            "text": "8h",
-            "value": "8h"
-          }
-        ],
-        "query": "1m,5m,10m,30m,1h,2h,4h,8h",
-        "refresh": 2,
-        "type": "interval"
       },
       {
         "current": {

--- a/files/grafana/provisioning/dashboards_json/traefik/traefik_access_logs.json
+++ b/files/grafana/provisioning/dashboards_json/traefik/traefik_access_logs.json
@@ -1,0 +1,227 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 5, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(count_over_time({job=\"traefik\", host=~\"$host\"} [$__range]))", "queryType": "instant", "refId": "A" }
+      ],
+      "title": "Total requests",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 5, "x": 5, "y": 0 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(count_over_time({job=\"traefik\", host=~\"$host\", status=~\"4..\"} [$__range]))", "queryType": "instant", "refId": "A" }
+      ],
+      "title": "4xx responses",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 5, "x": 10, "y": 0 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(count_over_time({job=\"traefik\", host=~\"$host\", status=~\"5..\"} [$__range]))", "queryType": "instant", "refId": "A" }
+      ],
+      "title": "5xx responses",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }, "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 15, "y": 0 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate({job=\"traefik\", host=~\"$host\"} [$__auto]))", "queryType": "range", "refId": "A" }
+      ],
+      "title": "Request rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 0 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "textMode": "auto" },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "quantile_over_time(0.95, {job=\"traefik\", host=~\"$host\", status=~\"[1-5]..\"} | json duration_ns=\"Duration\" | unwrap duration_ns [$__auto]) by () / 1e6", "queryType": "range", "refId": "A" }
+      ],
+      "title": "p95 latency (current)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 20, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "smooth", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 4 },
+      "id": 6,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (status) (rate({job=\"traefik\", host=~\"$host\"} [$__auto]))", "legendFormat": "{{status}}", "queryType": "range", "refId": "A" }
+      ],
+      "title": "Request rate by status code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 4 },
+      "id": 7,
+      "options": { "displayLabels": ["percent"], "legend": { "displayMode": "list", "placement": "right", "showLegend": true, "values": ["value"] }, "pieType": "donut", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "tooltip": { "mode": "single", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (status) (count_over_time({job=\"traefik\", host=~\"$host\"} [$__auto]))", "legendFormat": "{{status}}", "queryType": "range", "refId": "A" }
+      ],
+      "title": "Status code distribution",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "smooth", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 13 },
+      "id": 8,
+      "options": { "legend": { "calcs": ["last"], "displayMode": "table", "placement": "right", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "quantile_over_time(0.50, {job=\"traefik\", host=~\"$host\", status=~\"[1-5]..\"} | json duration_ns=\"Duration\" | unwrap duration_ns [$__auto]) by (host) / 1e6", "legendFormat": "p50 {{host}}", "queryType": "range", "refId": "A" },
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "quantile_over_time(0.95, {job=\"traefik\", host=~\"$host\", status=~\"[1-5]..\"} | json duration_ns=\"Duration\" | unwrap duration_ns [$__auto]) by (host) / 1e6", "legendFormat": "p95 {{host}}", "queryType": "range", "refId": "B" },
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "quantile_over_time(0.99, {job=\"traefik\", host=~\"$host\", status=~\"[1-5]..\"} | json duration_ns=\"Duration\" | unwrap duration_ns [$__auto]) by (host) / 1e6", "legendFormat": "p99 {{host}}", "queryType": "range", "refId": "C" }
+      ],
+      "title": "Request latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 13 },
+      "id": 9,
+      "options": { "displayLabels": ["percent"], "legend": { "displayMode": "list", "placement": "right", "showLegend": true, "values": ["value"] }, "pieType": "pie", "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }, "tooltip": { "mode": "single", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (method) (count_over_time({job=\"traefik\", host=~\"$host\"} [$__auto]))", "legendFormat": "{{method}}", "queryType": "range", "refId": "A" }
+      ],
+      "title": "Requests by method",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "Requests" }, "properties": [{ "id": "custom.cellOptions", "value": { "mode": "gradient", "type": "gauge" } }, { "id": "custom.width", "value": 160 }] }] },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 22 },
+      "id": 10,
+      "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "topk(15, sum by (request_host) (count_over_time({job=\"traefik\", host=~\"$host\"} | json request_host=\"RequestHost\" | request_host != \"\" | drop status, method, geoip_country_code [$__range])))", "format": "table", "queryType": "instant", "refId": "A" }
+      ],
+      "title": "Top requested hosts",
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true }, "includeByName": {}, "indexByName": {}, "renameByName": { "request_host": "Host", "Value #A": "Requests", "Value": "Requests" } } },
+        { "id": "sortBy", "options": { "fields": {}, "sort": [{ "desc": true, "field": "Requests" }] } }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false }, "unit": "short" }, "overrides": [{ "matcher": { "id": "byName", "options": "Requests" }, "properties": [{ "id": "custom.cellOptions", "value": { "mode": "gradient", "type": "gauge" } }, { "id": "custom.width", "value": 160 }] }] },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 22 },
+      "id": 11,
+      "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false }, "showHeader": true },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "topk(15, sum by (request_path) (count_over_time({job=\"traefik\", host=~\"$host\"} | json request_path=\"RequestPath\" | label_format request_path=`{{ regexReplaceAll \"\\\\?.*\" .request_path \"\" }}` | request_path != \"\" | drop status, method, geoip_country_code [$__range])))", "format": "table", "queryType": "instant", "refId": "A" }
+      ],
+      "title": "Top requested paths",
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true }, "includeByName": {}, "indexByName": {}, "renameByName": { "request_path": "Path", "Value #A": "Requests", "Value": "Requests" } } },
+        { "id": "sortBy", "options": { "fields": {}, "sort": [{ "desc": true, "field": "Requests" }] } }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "gridPos": { "h": 11, "w": 24, "x": 0, "y": 31 },
+      "id": 12,
+      "options": { "dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": true, "showCommonLabels": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false },
+      "targets": [
+        { "datasource": { "type": "loki", "uid": "${datasource}" }, "editorMode": "code", "expr": "{job=\"traefik\", host=~\"$host\"} | json", "queryType": "range", "refId": "A" }
+      ],
+      "title": "Access log",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["traefik", "loki", "logs"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": { "type": "loki", "uid": "${datasource}" },
+        "definition": "label_values({job=\"traefik\"}, host)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": { "label": "host", "refId": "LokiVariableQueryEditor-VariableQuery", "stream": "{job=\"traefik\"}", "type": 1 },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Traefik Access Logs",
+  "uid": "traefik-access-logs",
+  "weekStart": ""
+}

--- a/files/grafana/provisioning/dashboards_json/traefik/traefik_geo.json
+++ b/files/grafana/provisioning/dashboards_json/traefik/traefik_geo.json
@@ -1,0 +1,698 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Geolocation of external clients hitting public-facing Traefik (geoip-enriched access logs).",
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} [$__range]))",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "External requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(sum by (geoip_country_code) (count_over_time({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} [$__range])))",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Distinct countries",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} [$__auto]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "External request rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "description": "Markers at each client city (lat/lon from geoip), sized/colored by request count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "unit": "short",
+          "links": [
+            {
+              "title": "Drill into logs for ${__data.fields.City}",
+              "url": "/explore?schemaVersion=1&orgId=1&panes={\"loki\":{\"datasource\":\"${datasource}\",\"queries\":[{\"refId\":\"A\",\"datasource\":{\"type\":\"loki\",\"uid\":\"${datasource}\"},\"editorMode\":\"code\",\"expr\":\"{job=\\\"traefik\\\"} | geoip_city_name=\\\"${__data.fields.City}\\\"\",\"queryType\":\"range\"}],\"range\":{\"from\":\"now-6h\",\"to\":\"now\"}}}",
+              "targetBlank": true
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "basemap": {
+          "config": {},
+          "name": "Layer 0",
+          "type": "default"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showMeasure": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "layers": [
+          {
+            "config": {
+              "showLegend": true,
+              "style": {
+                "color": {
+                  "field": "Requests",
+                  "fixed": "dark-blue"
+                },
+                "opacity": 0.7,
+                "size": {
+                  "field": "Requests",
+                  "fixed": 5,
+                  "max": 30,
+                  "min": 4
+                },
+                "symbol": {
+                  "fixed": "img/icons/marker/circle.svg",
+                  "mode": "fixed"
+                },
+                "textConfig": {
+                  "fontSize": 12,
+                  "offsetX": 0,
+                  "offsetY": 0,
+                  "textAlign": "center",
+                  "textBaseline": "middle"
+                }
+              }
+            },
+            "location": {
+              "mode": "coords",
+              "latitude": "geoip_location_latitude",
+              "longitude": "geoip_location_longitude"
+            },
+            "name": "Requests by city",
+            "tooltip": true,
+            "type": "markers"
+          }
+        ],
+        "tooltip": {
+          "mode": "details"
+        },
+        "view": {
+          "id": "fit",
+          "allLayers": true,
+          "padding": 50,
+          "maxZoom": 8
+        }
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (geoip_location_latitude, geoip_location_longitude, geoip_city_name) (count_over_time({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} | geoip_location_latitude != \"\" [$__range]))",
+          "format": "table",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests by city (map)",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "targetField": "geoip_location_latitude",
+                "destinationType": "number"
+              },
+              {
+                "targetField": "geoip_location_longitude",
+                "destinationType": "number"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value #A": "Requests",
+              "Value": "Requests",
+              "geoip_city_name": "City"
+            }
+          }
+        }
+      ],
+      "type": "geomap"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, sum by (geoip_country_code) (count_over_time({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} [$__range])))",
+          "format": "table",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 20 countries",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "geoip_country_code": "Country",
+              "Value #A": "Requests",
+              "Value": "Requests"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Requests"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 16,
+        "x": 8,
+        "y": 20
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (geoip_country_code) (rate({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} [$__auto])))",
+          "legendFormat": "{{geoip_country_code}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "External request rate by country (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, sum by (client_ip, geoip_country_name, geoip_city_name) (count_over_time({job=\"traefik\", host=~\"$host\", geoip_country_code=~\".+\"} | json client_ip=\"ClientHost\" | drop status, method, geoip_country_code [$__range])))",
+          "format": "table",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 20 external client IPs",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "client_ip": 0,
+              "geoip_city_name": 1,
+              "geoip_country_name": 2,
+              "Value #A": 3,
+              "Value": 3
+            },
+            "renameByName": {
+              "client_ip": "Client IP",
+              "geoip_city_name": "City",
+              "geoip_country_name": "Country",
+              "Value #A": "Requests",
+              "Value": "Requests"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Requests"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "traefik",
+    "loki",
+    "geo"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": {
+          "type": "loki",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values({job=\"traefik\"}, host)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": {
+          "label": "host",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{job=\"traefik\"}",
+          "type": 1
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Traefik Geo",
+  "uid": "traefik-geo",
+  "weekStart": ""
+}

--- a/files/grafana/provisioning/dashboards_json/traefik/traefik_intranet.json
+++ b/files/grafana/provisioning/dashboards_json/traefik/traefik_intranet.json
@@ -1,0 +1,648 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Traefik traffic from internal/intranet clients (RFC1918 + Tailscale source IPs).",
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({job=\"traefik\", host=~\"$host\"} | json client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | drop client_ip, status, method, geoip_country_code [$__range]))",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Internal requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(sum by (client_ip) (count_over_time({job=\"traefik\", host=~\"$host\"} | json client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | drop status, method, geoip_country_code [$__range])))",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Distinct internal clients",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate({job=\"traefik\", host=~\"$host\"} | json client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | drop client_ip, status, method, geoip_country_code [$__auto]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Internal request rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, sum by (client_ip) (count_over_time({job=\"traefik\", host=~\"$host\"} | json client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | drop status, method, geoip_country_code [$__range])))",
+          "format": "table",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 20 internal clients",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "client_ip": "Client IP",
+              "Value #A": "Requests",
+              "Value": "Requests"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Requests"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "13.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, sum by (request_host) (count_over_time({job=\"traefik\", host=~\"$host\"} | json request_host=\"RequestHost\", client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | request_host != \"\" | drop status, method, geoip_country_code [$__range])))",
+          "format": "table",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 20 requested hosts (internal)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "request_host": "Host",
+              "Value #A": "Requests",
+              "Value": "Requests"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Requests"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 13
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (rate({job=\"traefik\", host=~\"$host\"} | json client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | drop method, geoip_country_code [$__auto]))",
+          "legendFormat": "{{status}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Internal request rate by status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "id": 7,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (status) (count_over_time({job=\"traefik\", host=~\"$host\"} | json client_ip=\"ClientHost\" | client_ip=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*` | drop method, geoip_country_code [$__auto]))",
+          "legendFormat": "{{status}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Status distribution (internal)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 8,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "{job=\"traefik\", host=~\"$host\"} | json | ClientHost=~`^(10\\.|172\\.(1[6-9]|2[0-9]|3[01])\\.|192\\.168\\.|100\\.|127\\.).*`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Internal access log",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "traefik",
+    "loki",
+    "intranet"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {},
+        "datasource": {
+          "type": "loki",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values({job=\"traefik\"}, host)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": {
+          "label": "host",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{job=\"traefik\"}",
+          "type": 1
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Traefik Intranet",
+  "uid": "traefik-intranet",
+  "weekStart": ""
+}

--- a/files/grafana/provisioning/datasources/loki.yaml
+++ b/files/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    isDefault: false
+    editable: false

--- a/files/loki/loki-config.yaml
+++ b/files/loki/loki-config.yaml
@@ -1,0 +1,39 @@
+---
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  retention_period: 720h
+
+compactor:
+  working_directory: /loki/retention
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h

--- a/files/loki/loki-config.yaml
+++ b/files/loki/loki-config.yaml
@@ -37,3 +37,4 @@ compactor:
   compaction_interval: 10m
   retention_enabled: true
   retention_delete_delay: 2h
+  delete_request_store: filesystem

--- a/files/traefik/traefik-dev.yaml
+++ b/files/traefik/traefik-dev.yaml
@@ -17,6 +17,10 @@ entryPoints:
 accessLog:
   filepath: /etc/traefik/access.log
   format: json
+  bufferingSize: 100
+  filters:
+    retryAttempts: true
+    minDuration: "10ms"
   fields:
     defaultMode: keep
     names:

--- a/files/traefik/traefik-prod-no-file-provider.yaml
+++ b/files/traefik/traefik-prod-no-file-provider.yaml
@@ -19,6 +19,10 @@ entryPoints:
 accessLog:
   filepath: /etc/traefik/access.log
   format: json
+  bufferingSize: 100
+  filters:
+    retryAttempts: true
+    minDuration: "10ms"
   fields:
     defaultMode: keep
     names:

--- a/files/traefik/traefik-prod.yaml
+++ b/files/traefik/traefik-prod.yaml
@@ -19,6 +19,10 @@ entryPoints:
 accessLog:
   filepath: /etc/traefik/access.log
   format: json
+  bufferingSize: 100
+  filters:
+    retryAttempts: true
+    minDuration: "10ms"
   fields:
     defaultMode: keep
     names:

--- a/inventories/home/group_vars/all/main.yaml
+++ b/inventories/home/group_vars/all/main.yaml
@@ -39,6 +39,10 @@ ntfy_alertmanager_base_url: "https://{{ ntfy_alertmanager_domain }}"
 grafana_domain: "grafana.home.stechsolutions.ca"
 grafana_base_url: "https://{{ grafana_domain }}"
 
+# loki variables
+loki_domain: "loki.home.stechsolutions.ca"
+loki_push_url: "https://{{ loki_domain }}/loki/api/v1/push"
+
 # geerlingguy.security role variables
 # https://galaxy.ansible.com/geerlingguy/security
 security_ssh_port: 22

--- a/inventories/home/group_vars/pihole.yaml
+++ b/inventories/home/group_vars/pihole.yaml
@@ -84,6 +84,9 @@ pihole_cname_entries:
   - domain: "grafana.home.stechsolutions.ca"
     target: "docker-02.home.stechsolutions.ca"
     add_hostname: true
+  - domain: "loki.home.stechsolutions.ca"
+    target: "docker-02.home.stechsolutions.ca"
+    add_hostname: true
   - domain: "homepage.home.stechsolutions.ca"
     target: "docker-02.home.stechsolutions.ca"
     add_hostname: true

--- a/inventories/home/host_vars/docker-01.home.stechsolutions.ca/docker.yaml
+++ b/inventories/home/host_vars/docker-01.home.stechsolutions.ca/docker.yaml
@@ -21,6 +21,19 @@ docker_daemon_options:
 # docker container paths. All found files will be processed and copied to the docker host
 # docker_configuration_paths:
 
+docker_logrotate_configs:
+  - name: traefik
+    paths:
+      - "/home/{{ default_user }}/docker_mounts/proxy/traefik/access.log"
+    rotation_period: daily
+    rotate_count: 14
+    size: "100M"
+    compress: true
+    delay_compress: true
+    missing_ok: true
+    not_if_empty: true
+    copy_truncate: true
+
 docker_mounts_subfolders:
   - name: downloader_profilarr
     dest: /home/{{ default_user }}/docker_mounts/downloader/profilarr

--- a/inventories/home/host_vars/docker-02.home.stechsolutions.ca/base.yaml
+++ b/inventories/home/host_vars/docker-02.home.stechsolutions.ca/base.yaml
@@ -1,10 +1,4 @@
 ---
-base_host_additional_packages:
-  - nvidia-driver-550
-  - nvidia-utils-550
-  - wireguard
-  - wireguard-tools
-
 # Install Grafana Alloy to ship Traefik access logs to Loki
 base_alloy_setup: true
 

--- a/inventories/home/host_vars/docker-02.home.stechsolutions.ca/docker.yaml
+++ b/inventories/home/host_vars/docker-02.home.stechsolutions.ca/docker.yaml
@@ -18,6 +18,19 @@ wud_trigger_ntfy_sh_topic: wud
 wud_trigger_ntfy_sh_priority: 2
 wud_trigger_ntfy_sh_auth_token: "{{ secret_ntfy_tokens.WUD }}"
 
+docker_logrotate_configs:
+  - name: traefik
+    paths:
+      - "/home/{{ default_user }}/docker_mounts/proxy/traefik/access.log"
+    rotation_period: daily
+    rotate_count: 14
+    size: "100M"
+    compress: true
+    delay_compress: true
+    missing_ok: true
+    not_if_empty: true
+    copy_truncate: true
+
 # docker container paths. All found files will be processed and copied to the docker host
 docker_configuration_paths:
   - name: homepage
@@ -54,6 +67,12 @@ docker_configuration_files:
     dest: /home/{{ default_user }}/docker_mounts/proxy/traefik/dynamic/unifi.yaml
     mode: '0664'
     container_name: traefik
+  # loki configuration file
+  - name: loki-config.yaml
+    src: "{{ inventory_dir }}/../../files/loki/loki-config.yaml"
+    dest: /home/{{ default_user }}/docker_mounts/monitoring/loki/config/loki-config.yaml
+    mode: '0664'
+    container_name: loki
   # prometheus configuration files
   - name: prometheus_alertmanager_config.yaml
     src: "{{ inventory_dir }}/../../files/alertmanager/alertmanager.yaml.j2"
@@ -103,6 +122,15 @@ docker_mounts_subfolders:
     dest: /home/{{ default_user }}/docker_mounts/monitoring/grafana/data
     mode: '0775'
     container_name: grafana
+  # loki docker mounts
+  - name: monitoring_loki
+    dest: /home/{{ default_user }}/docker_mounts/monitoring/loki
+    mode: '0775'
+    container_name: loki
+  - name: monitoring_loki_config
+    dest: /home/{{ default_user }}/docker_mounts/monitoring/loki/config
+    mode: '0775'
+    container_name: loki
   # filestash docker mounts
   - name: files_filestash
     dest: /home/{{ default_user }}/docker_mounts/files/filestash

--- a/inventories/home/host_vars/docker-02.home.stechsolutions.ca/docker_compose/monitoring.yaml.j2
+++ b/inventories/home/host_vars/docker-02.home.stechsolutions.ca/docker_compose/monitoring.yaml.j2
@@ -259,6 +259,36 @@ services:
       - "wud.tag.include=^v?\\d+\\.\\d+\\.\\d+$"
       - "wud.link.template=https://grafana.com/docs/grafana/latest/whatsnew/"
 
+  loki:
+    image: grafana/loki:3.5.0
+    user: 1000:1000
+    networks:
+      - traefik
+      - prometheus_exporter
+    container_name: loki
+    volumes:
+      - /home/{{ default_user }}/docker_mounts/monitoring/loki:/loki
+      - /home/{{ default_user }}/docker_mounts/monitoring/loki/config/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+    command: -config.file=/etc/loki/loki-config.yaml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --tries=1 http://localhost:3100/ready -O - | grep -q 'ready' || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik"
+      - "traefik.http.routers.loki.rule=Host(`{{ loki_domain }}`)"
+      - "traefik.http.services.loki.loadbalancer.server.port=3100"
+      - "traefik.http.routers.loki.entrypoints=websecure"
+      - "traefik.http.routers.loki.tls.certresolver=letsencrypt"
+      - "traefik.http.middlewares.loki-IPAllowList.IPAllowList.sourcerange=100.64.0.0/10,10.0.0.0/8,172.16.0.0/12"
+      - "traefik.http.routers.loki.middlewares=loki-IPAllowList"
+      - "wud.tag.include=^v?\\d+\\.\\d+\\.\\d+$"
+      - "wud.link.template=https://github.com/grafana/loki/releases"
+
 networks:
   traefik:
     name: traefik

--- a/inventories/home/host_vars/docker-cloud-01/base.yaml
+++ b/inventories/home/host_vars/docker-cloud-01/base.yaml
@@ -1,10 +1,4 @@
 ---
-base_host_additional_packages:
-  - nvidia-driver-550
-  - nvidia-utils-550
-  - wireguard
-  - wireguard-tools
-
 # Install Grafana Alloy to ship Traefik access logs to Loki
 base_alloy_setup: true
 

--- a/inventories/home/host_vars/docker-cloud-01/base.yaml
+++ b/inventories/home/host_vars/docker-cloud-01/base.yaml
@@ -10,6 +10,12 @@ base_alloy_log_sources:
       status: DownstreamStatus
       method: RequestMethod
       path: RequestPath
+      client: ClientHost
+    geoip_source: client
     label_keys:
       - status
       - method
+
+# Monthly GeoIP database refresh pings Healthchecks (this host runs the HC server).
+base_alloy_geoip_hc_url: "https://hc.stechsolutions.ca/ping/"
+base_alloy_geoip_hc_uuid: "{{ secret_hc_projects['Stechsolutions'].ping_key }}/geoip-docker-cloud-01"

--- a/inventories/home/host_vars/docker-cloud-01/docker.yaml
+++ b/inventories/home/host_vars/docker-cloud-01/docker.yaml
@@ -1,6 +1,19 @@
 ---
 # Host variables for docker-cloud-01 host.
 
+docker_logrotate_configs:
+  - name: traefik
+    paths:
+      - "/home/{{ default_user }}/docker_mounts/proxy/traefik/access.log"
+    rotation_period: daily
+    rotate_count: 14
+    size: "100M"
+    compress: true
+    delay_compress: true
+    missing_ok: true
+    not_if_empty: true
+    copy_truncate: true
+
 # docker container paths. All found files will be processed and copied to the docker host
 docker_configuration_paths:
   - name: homepage_media

--- a/inventories/home/host_vars/docker-cloud-01/healthchecks.yaml
+++ b/inventories/home/host_vars/docker-cloud-01/healthchecks.yaml
@@ -112,3 +112,13 @@ hc_checks:
     timeout: 86400
     grace: 43200
     channels: "{{ hc_channels[0].name }},{{ hc_channels[1].name }}"
+  # Check for the monthly Alloy GeoIP database update (cron: 5th of month)
+  # timeout 31d + grace 2d exceeds the longest month-to-month gap, so a normal
+  # monthly run never false-alarms, but a genuinely missed run alerts within ~2 days.
+  - project: "{{ hc_projects[0].name }}"
+    name: Alloy GeoIP Update
+    slug: geoip-docker-cloud-01
+    desc: Monthly DB-IP GeoIP database refresh for Alloy
+    timeout: 2678400
+    grace: 172800
+    channels: "{{ hc_channels[0].name }},{{ hc_channels[1].name }}"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,7 @@
 ---
 collections:
   - name: community.general
+    version: ">=12.5.0"
   - name: community.docker
     version: ">=3.6.0"
   - name: community.digitalocean

--- a/roles/base/defaults/main.yaml
+++ b/roles/base/defaults/main.yaml
@@ -142,5 +142,26 @@ base_alloy_apt_keyring_path: /usr/share/keyrings/grafana.gpg
 base_alloy_apt_repository: "deb [signed-by={{ base_alloy_apt_keyring_path }}] https://apt.grafana.com stable main"
 
 # Log sources for Alloy to scrape and forward to Loki.
-# Each entry: name, path, job, optional json_expressions (map), optional label_keys (list).
+# Each entry: name, path, job, optional json_expressions (map), optional label_keys
+# (list), and optional geoip_source (the extracted field holding the client IP to
+# geolocate). When any source sets geoip_source, the DB-IP database is deployed.
 base_alloy_log_sources: []
+
+# Offline GeoIP database (DB-IP City Lite, MaxMind-compatible .mmdb, no account
+# required). DB-IP publishes a fresh build monthly; the updater script appends the
+# current YYYY-MM to the base URL at run time, so the cron always fetches the
+# latest month. Ansible only deploys the script + cron; the host owns the refresh.
+base_alloy_geoip_db_path: /etc/alloy/geoip/dbip-city-lite.mmdb
+base_alloy_geoip_db_baseurl: "https://download.db-ip.com/free/dbip-city-lite"
+base_alloy_geoip_update_script: /usr/local/bin/update-geoip-db.sh
+
+# Monthly refresh schedule (day-of-month); DB-IP publishes around the 1st.
+base_alloy_geoip_update_cron_minute: "30"
+base_alloy_geoip_update_cron_hour: "4"
+base_alloy_geoip_update_cron_day: "5"
+
+# Optional Healthchecks ping (set _hc_uuid to enable). Mirrors rclone/sanoid:
+#   base_alloy_geoip_hc_url:  "https://hc.stechsolutions.ca/ping/"
+#   base_alloy_geoip_hc_uuid: "{{ secret_hc_projects['Stechsolutions'].ping_key }}/geoip-<host>"
+base_alloy_geoip_hc_url: ""
+base_alloy_geoip_hc_uuid: ""

--- a/roles/base/defaults/main.yaml
+++ b/roles/base/defaults/main.yaml
@@ -132,3 +132,15 @@ base_node_exporter_mount_points_exclude: '^/(dev|proc|run|sys|media|export|var/l
 # Directory for prometheus-node-exporter textfile collector
 # Scripts write .prom files here; node_exporter reads them
 base_node_exporter_textfile_dir: /var/lib/prometheus/node-exporter
+
+# Whether to install and configure Grafana Alloy (host-level log shipping agent)
+base_alloy_setup: false
+
+# Grafana apt repository (used to install Alloy)
+base_alloy_apt_signkey: https://apt.grafana.com/gpg.key
+base_alloy_apt_keyring_path: /usr/share/keyrings/grafana.gpg
+base_alloy_apt_repository: "deb [signed-by={{ base_alloy_apt_keyring_path }}] https://apt.grafana.com stable main"
+
+# Log sources for Alloy to scrape and forward to Loki.
+# Each entry: name, path, job, optional json_expressions (map), optional label_keys (list).
+base_alloy_log_sources: []

--- a/roles/base/handlers/main.yaml
+++ b/roles/base/handlers/main.yaml
@@ -35,3 +35,11 @@
     daemon_reload: true
   changed_when: true
   become: true
+
+# Restart alloy
+- name: Restart alloy
+  ansible.builtin.systemd:
+    name: alloy
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/base/tasks/main.yaml
+++ b/roles/base/tasks/main.yaml
@@ -15,6 +15,8 @@
 #   - base_netplan: dictionary of netplan configuration
 #   - base_node_exporter_zfs_collector: boolean to enable ZFS collector for node_exporter
 #   - base_node_exporter_textfile_dir: path for textfile collector (default: /var/lib/prometheus/node-exporter)
+#   - base_alloy_setup: boolean to install and configure Grafana Alloy log shipping agent
+#   - base_alloy_log_sources: list of log sources for Alloy to ship to Loki
 
 
 # Update and upgrade apt packages
@@ -124,6 +126,14 @@
   tags:
     - base
     - base.node_exporter
+
+# Install and configure Grafana Alloy when the flag is set
+- name: Configure Grafana Alloy
+  ansible.builtin.include_tasks: setup_alloy.yaml
+  when: base_alloy_setup is true
+  tags:
+    - base
+    - base.alloy
 
 # set specified systemd services to the specified state and status
 - name: Set specified systemd services to the specified state and status

--- a/roles/base/tasks/setup_alloy.yaml
+++ b/roles/base/tasks/setup_alloy.yaml
@@ -49,6 +49,7 @@
   ansible.builtin.apt:
     name: alloy
     state: present
+    update_cache: true
   become: true
   tags:
     - base

--- a/roles/base/tasks/setup_alloy.yaml
+++ b/roles/base/tasks/setup_alloy.yaml
@@ -54,54 +54,73 @@
     - base
     - base.alloy
 
-# The systemd drop-in must be root-owned (systemd ignores non-root unit files);
-# its User=/Group= directives make the Alloy *process* run as default_user, so it
-# can traverse /home/{{ default_user }} and read the (root-owned, world-readable)
-# Traefik access.log without the process running as root.
-- name: Create Alloy systemd override directory
+# Deploy the offline GeoIP database when any log source requests geo enrichment.
+# Must land before the config is rendered/restarted, since stage.geoip fails to
+# load if the db file is missing.
+- name: Create Alloy GeoIP database directory
   ansible.builtin.file:
-    path: /etc/systemd/system/alloy.service.d
+    path: "{{ base_alloy_geoip_db_path | dirname }}"
     state: directory
     owner: root
     group: root
     mode: "0755"
   become: true
+  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
   tags:
     - base
     - base.alloy
 
-- name: Deploy Alloy systemd override (sets process User/Group to default_user)
+- name: Deploy GeoIP database updater script
   ansible.builtin.template:
-    src: alloy_override.conf.j2
-    dest: /etc/systemd/system/alloy.service.d/override.conf
+    src: update-geoip-db.sh.j2
+    dest: "{{ base_alloy_geoip_update_script }}"
     owner: root
     group: root
-    mode: "0644"
+    mode: "0755"
   become: true
-  notify: Restart alloy
+  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
   tags:
     - base
     - base.alloy
 
-- name: Ensure Alloy data directory is owned by default_user
-  ansible.builtin.file:
-    path: /var/lib/alloy
-    state: directory
-    owner: "{{ default_user }}"
-    group: "{{ default_user }}"
-    mode: "0750"
-    recurse: true
+# Bootstrap the database on first install so stage.geoip has a db to load before
+# the first scheduled run. Idempotent via creates; the monthly cron owns refresh.
+- name: Populate GeoIP database on first install
+  ansible.builtin.command:
+    cmd: "{{ base_alloy_geoip_update_script }}"
+    creates: "{{ base_alloy_geoip_db_path }}"
   become: true
+  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
   tags:
     - base
     - base.alloy
 
+- name: Schedule monthly GeoIP database update
+  ansible.builtin.cron:
+    name: Update Alloy GeoIP database
+    minute: "{{ base_alloy_geoip_update_cron_minute }}"
+    hour: "{{ base_alloy_geoip_update_cron_hour }}"
+    day: "{{ base_alloy_geoip_update_cron_day }}"
+    user: root
+    job: "{{ base_alloy_geoip_update_script }}"
+    state: present
+  become: true
+  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
+  tags:
+    - base
+    - base.alloy
+
+# Alloy runs as its packaged, low-privilege `alloy` system user (the service
+# default). No run-as-user override is needed: /home/{{ default_user }} is
+# world-traversable (0755) and the Traefik access.log is world-readable, so the
+# alloy user can read it without elevated privileges or ownership changes. The
+# package owns /etc/alloy and /var/lib/alloy; we only template the config in.
 - name: Deploy Alloy configuration
   ansible.builtin.template:
     src: config.alloy.j2
     dest: /etc/alloy/config.alloy
-    owner: "{{ default_user }}"
-    group: "{{ default_user }}"
+    owner: root
+    group: root
     mode: "0644"
   become: true
   notify: Restart alloy

--- a/roles/base/tasks/setup_alloy.yaml
+++ b/roles/base/tasks/setup_alloy.yaml
@@ -26,6 +26,15 @@
     - base
     - base.alloy
 
+- name: Remove armored Grafana apt signing key
+  ansible.builtin.file:
+    path: "{{ base_alloy_apt_keyring_path }}.asc"
+    state: absent
+  become: true
+  tags:
+    - base
+    - base.alloy
+
 - name: Add Grafana repo to apt sources
   ansible.builtin.apt_repository:
     repo: "{{ base_alloy_apt_repository }}"
@@ -40,7 +49,6 @@
   ansible.builtin.apt:
     name: alloy
     state: present
-    update_cache: true
   become: true
   tags:
     - base

--- a/roles/base/tasks/setup_alloy.yaml
+++ b/roles/base/tasks/setup_alloy.yaml
@@ -56,59 +56,46 @@
 
 # Deploy the offline GeoIP database when any log source requests geo enrichment.
 # Must land before the config is rendered/restarted, since stage.geoip fails to
-# load if the db file is missing.
-- name: Create Alloy GeoIP database directory
-  ansible.builtin.file:
-    path: "{{ base_alloy_geoip_db_path | dirname }}"
-    state: directory
-    owner: root
-    group: root
-    mode: "0755"
+# load if the db file is missing. Block-level when/become/tags apply to all tasks.
+- name: Set up GeoIP database enrichment
   become: true
   when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
   tags:
     - base
     - base.alloy
+  block:
+    - name: Create Alloy GeoIP database directory
+      ansible.builtin.file:
+        path: "{{ base_alloy_geoip_db_path | dirname }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
 
-- name: Deploy GeoIP database updater script
-  ansible.builtin.template:
-    src: update-geoip-db.sh.j2
-    dest: "{{ base_alloy_geoip_update_script }}"
-    owner: root
-    group: root
-    mode: "0755"
-  become: true
-  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
-  tags:
-    - base
-    - base.alloy
+    - name: Deploy GeoIP database updater script
+      ansible.builtin.template:
+        src: update-geoip-db.sh.j2
+        dest: "{{ base_alloy_geoip_update_script }}"
+        owner: root
+        group: root
+        mode: "0755"
 
-# Bootstrap the database on first install so stage.geoip has a db to load before
-# the first scheduled run. Idempotent via creates; the monthly cron owns refresh.
-- name: Populate GeoIP database on first install
-  ansible.builtin.command:
-    cmd: "{{ base_alloy_geoip_update_script }}"
-    creates: "{{ base_alloy_geoip_db_path }}"
-  become: true
-  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
-  tags:
-    - base
-    - base.alloy
+    # Bootstrap the database on first install so stage.geoip has a db to load
+    # before the first scheduled run. Idempotent via creates; cron owns refresh.
+    - name: Populate GeoIP database on first install
+      ansible.builtin.command:
+        cmd: "{{ base_alloy_geoip_update_script }}"
+        creates: "{{ base_alloy_geoip_db_path }}"
 
-- name: Schedule monthly GeoIP database update
-  ansible.builtin.cron:
-    name: Update Alloy GeoIP database
-    minute: "{{ base_alloy_geoip_update_cron_minute }}"
-    hour: "{{ base_alloy_geoip_update_cron_hour }}"
-    day: "{{ base_alloy_geoip_update_cron_day }}"
-    user: root
-    job: "{{ base_alloy_geoip_update_script }}"
-    state: present
-  become: true
-  when: base_alloy_log_sources | selectattr('geoip_source', 'defined') | list | length > 0
-  tags:
-    - base
-    - base.alloy
+    - name: Schedule monthly GeoIP database update
+      ansible.builtin.cron:
+        name: Update Alloy GeoIP database
+        minute: "{{ base_alloy_geoip_update_cron_minute }}"
+        hour: "{{ base_alloy_geoip_update_cron_hour }}"
+        day: "{{ base_alloy_geoip_update_cron_day }}"
+        user: root
+        job: "{{ base_alloy_geoip_update_script }}"
+        state: present
 
 # Alloy runs as its packaged, low-privilege `alloy` system user (the service
 # default). No run-as-user override is needed: /home/{{ default_user }} is

--- a/roles/base/tasks/setup_alloy.yaml
+++ b/roles/base/tasks/setup_alloy.yaml
@@ -1,7 +1,7 @@
 ---
 # Install and configure Grafana Alloy as a host-level log shipping agent.
 # Installed from Grafana's apt repo (same keyring + signed-by pattern as the
-# tailscale role). Ships logs defined in alloy_log_sources to Loki.
+# tailscale role). Ships logs defined in base_alloy_log_sources to Loki.
 #
 # inputs:
 #   - base_alloy_log_sources: list of log sources to scrape and forward to Loki

--- a/roles/base/tasks/setup_alloy.yaml
+++ b/roles/base/tasks/setup_alloy.yaml
@@ -1,0 +1,114 @@
+---
+# Install and configure Grafana Alloy as a host-level log shipping agent.
+# Installed from Grafana's apt repo (same keyring + signed-by pattern as the
+# tailscale role). Ships logs defined in alloy_log_sources to Loki.
+#
+# inputs:
+#   - base_alloy_log_sources: list of log sources to scrape and forward to Loki
+#   - loki_push_url: Loki push endpoint URL
+
+- name: Add Grafana apt signing key
+  ansible.builtin.get_url:
+    url: "{{ base_alloy_apt_signkey }}"
+    dest: "{{ base_alloy_apt_keyring_path }}.asc"
+    mode: "0644"
+  become: true
+  tags:
+    - base
+    - base.alloy
+
+- name: Dearmor Grafana apt signing key
+  ansible.builtin.command:
+    cmd: "gpg --batch --yes --dearmor -o {{ base_alloy_apt_keyring_path }} {{ base_alloy_apt_keyring_path }}.asc"
+    creates: "{{ base_alloy_apt_keyring_path }}"
+  become: true
+  tags:
+    - base
+    - base.alloy
+
+- name: Add Grafana repo to apt sources
+  ansible.builtin.apt_repository:
+    repo: "{{ base_alloy_apt_repository }}"
+    filename: grafana
+    state: present
+  become: true
+  tags:
+    - base
+    - base.alloy
+
+- name: Install Alloy
+  ansible.builtin.apt:
+    name: alloy
+    state: present
+    update_cache: true
+  become: true
+  tags:
+    - base
+    - base.alloy
+
+# The systemd drop-in must be root-owned (systemd ignores non-root unit files);
+# its User=/Group= directives make the Alloy *process* run as default_user, so it
+# can traverse /home/{{ default_user }} and read the (root-owned, world-readable)
+# Traefik access.log without the process running as root.
+- name: Create Alloy systemd override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/alloy.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+  tags:
+    - base
+    - base.alloy
+
+- name: Deploy Alloy systemd override (sets process User/Group to default_user)
+  ansible.builtin.template:
+    src: alloy_override.conf.j2
+    dest: /etc/systemd/system/alloy.service.d/override.conf
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  notify: Restart alloy
+  tags:
+    - base
+    - base.alloy
+
+- name: Ensure Alloy data directory is owned by default_user
+  ansible.builtin.file:
+    path: /var/lib/alloy
+    state: directory
+    owner: "{{ default_user }}"
+    group: "{{ default_user }}"
+    mode: "0750"
+    recurse: true
+  become: true
+  tags:
+    - base
+    - base.alloy
+
+- name: Deploy Alloy configuration
+  ansible.builtin.template:
+    src: config.alloy.j2
+    dest: /etc/alloy/config.alloy
+    owner: "{{ default_user }}"
+    group: "{{ default_user }}"
+    mode: "0644"
+  become: true
+  notify: Restart alloy
+  tags:
+    - base
+    - base.alloy
+
+- name: Enable and start Alloy service
+  ansible.builtin.systemd:
+    name: alloy
+    state: started
+    enabled: true
+    daemon_reload: true
+  become: true
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags:
+    - base
+    - base.alloy

--- a/roles/base/templates/alloy_override.conf.j2
+++ b/roles/base/templates/alloy_override.conf.j2
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+[Service]
+User={{ default_user }}
+Group={{ default_user }}

--- a/roles/base/templates/alloy_override.conf.j2
+++ b/roles/base/templates/alloy_override.conf.j2
@@ -1,4 +1,0 @@
-{{ ansible_managed | comment }}
-[Service]
-User={{ default_user }}
-Group={{ default_user }}

--- a/roles/base/templates/config.alloy.j2
+++ b/roles/base/templates/config.alloy.j2
@@ -31,12 +31,36 @@ loki.process "{{ src.name }}" {
     }
   }
 {% endif %}
-{% if src.label_keys is defined %}
+{% if src.geoip_source is defined %}
+  // Enrich the client IP with geo data from the offline DB-IP database.
+  // Private/internal IPs simply yield no geo fields (left empty).
+  stage.geoip {
+    source  = "{{ src.geoip_source }}"
+    db      = "{{ base_alloy_geoip_db_path }}"
+    db_type = "city"
+  }
+{% endif %}
+{% if src.label_keys is defined or src.geoip_source is defined %}
   stage.labels {
     values = {
-{% for label in src.label_keys %}
+{% for label in src.label_keys | default([]) %}
       {{ label }} = "",
 {% endfor %}
+{% if src.geoip_source is defined %}
+      geoip_country_code = "",
+{% endif %}
+    }
+  }
+{% endif %}
+{% if src.geoip_source is defined %}
+  // High-cardinality geo fields stay as structured metadata, never labels.
+  stage.structured_metadata {
+    values = {
+      {{ src.geoip_source }} = "",
+      geoip_country_name = "",
+      geoip_city_name = "",
+      geoip_location_latitude = "",
+      geoip_location_longitude = "",
     }
   }
 {% endif %}

--- a/roles/base/templates/config.alloy.j2
+++ b/roles/base/templates/config.alloy.j2
@@ -1,0 +1,45 @@
+// {{ ansible_managed }}
+// Grafana Alloy configuration - log shipping to Loki.
+// Log sources are driven by the alloy_log_sources variable.
+
+loki.write "default" {
+  endpoint {
+    url = "{{ loki_push_url }}"
+  }
+  external_labels = {
+    host = "{{ inventory_hostname }}",
+  }
+}
+{% for src in base_alloy_log_sources %}
+
+local.file_match "{{ src.name }}" {
+  path_targets = [{"__path__" = "{{ src.path }}", "job" = "{{ src.job }}"}]
+}
+
+loki.source.file "{{ src.name }}" {
+  targets    = local.file_match.{{ src.name }}.targets
+  forward_to = [loki.process.{{ src.name }}.receiver]
+}
+
+loki.process "{{ src.name }}" {
+{% if src.json_expressions is defined %}
+  stage.json {
+    expressions = {
+{% for key, value in src.json_expressions.items() %}
+      {{ key }} = "{{ value }}",
+{% endfor %}
+    }
+  }
+{% endif %}
+{% if src.label_keys is defined %}
+  stage.labels {
+    values = {
+{% for label in src.label_keys %}
+      {{ label }} = "",
+{% endfor %}
+    }
+  }
+{% endif %}
+  forward_to = [loki.write.default.receiver]
+}
+{% endfor %}

--- a/roles/base/templates/config.alloy.j2
+++ b/roles/base/templates/config.alloy.j2
@@ -11,6 +11,7 @@ loki.write "default" {
   }
 }
 {% for src in base_alloy_log_sources %}
+{% set geo = src.geoip_source is defined %}
 
 local.file_match "{{ src.name }}" {
   path_targets = [{"__path__" = "{{ src.path }}", "job" = "{{ src.job }}"}]
@@ -31,7 +32,7 @@ loki.process "{{ src.name }}" {
     }
   }
 {% endif %}
-{% if src.geoip_source is defined %}
+{% if geo %}
   // Enrich the client IP with geo data from the offline DB-IP database.
   // Private/internal IPs simply yield no geo fields (left empty).
   stage.geoip {
@@ -40,19 +41,19 @@ loki.process "{{ src.name }}" {
     db_type = "city"
   }
 {% endif %}
-{% if src.label_keys is defined or src.geoip_source is defined %}
+{% if src.label_keys is defined or geo %}
   stage.labels {
     values = {
 {% for label in src.label_keys | default([]) %}
       {{ label }} = "",
 {% endfor %}
-{% if src.geoip_source is defined %}
+{% if geo %}
       geoip_country_code = "",
 {% endif %}
     }
   }
 {% endif %}
-{% if src.geoip_source is defined %}
+{% if geo %}
   // High-cardinality geo fields stay as structured metadata, never labels.
   stage.structured_metadata {
     values = {

--- a/roles/base/templates/config.alloy.j2
+++ b/roles/base/templates/config.alloy.j2
@@ -1,6 +1,6 @@
 // {{ ansible_managed }}
 // Grafana Alloy configuration - log shipping to Loki.
-// Log sources are driven by the alloy_log_sources variable.
+// Log sources are driven by the base_alloy_log_sources variable.
 
 loki.write "default" {
   endpoint {

--- a/roles/base/templates/update-geoip-db.sh.j2
+++ b/roles/base/templates/update-geoip-db.sh.j2
@@ -1,0 +1,56 @@
+#!/bin/bash
+# {{ ansible_managed }}
+#
+# Grafana Alloy GeoIP database updater.
+# Downloads the current month's DB-IP City Lite database, sanity-checks it,
+# atomically installs it, restarts Alloy, and (optionally) pings Healthchecks
+# (start / success / fail). Intended to run monthly from cron as root.
+
+set -uo pipefail
+
+DB_PATH="{{ base_alloy_geoip_db_path }}"
+DB_URL="{{ base_alloy_geoip_db_baseurl }}-$(date +%Y-%m).mmdb.gz"
+HC_URL="{{ base_alloy_geoip_hc_url }}{{ base_alloy_geoip_hc_uuid }}"
+HC_ENABLED="{{ 'true' if base_alloy_geoip_hc_uuid | default('') | length > 0 else 'false' }}"
+LOGFILE="/tmp/geoip_update_$(date +%Y-%m-%d).log"
+
+log() {
+  printf '%s - %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" | tee -a "$LOGFILE"
+}
+
+# $1 = start | fail | (empty for success). No-op when Healthchecks isn't configured.
+hc_ping() {
+  [ "$HC_ENABLED" = "true" ] || return 0
+  curl -fsS -m 10 --retry 3 --data-raw "$(tail -n 20 "$LOGFILE" 2>/dev/null)" \
+    "${HC_URL}${1:+/$1}" >/dev/null 2>&1 || log "Healthcheck ping '${1:-success}' failed."
+}
+
+fail() {
+  log "ERROR: $1"
+  hc_ping fail
+  exit 1
+}
+
+hc_ping start
+log "Downloading GeoIP database from $DB_URL"
+
+TMP_GZ="$(mktemp --suffix=.mmdb.gz)"
+trap 'rm -f "$TMP_GZ" "${TMP_GZ%.gz}"' EXIT
+
+curl -fsS -m 180 --retry 3 -o "$TMP_GZ" "$DB_URL" || fail "Download failed from $DB_URL"
+gunzip -f "$TMP_GZ" || fail "Decompression failed."
+TMP_DB="${TMP_GZ%.gz}"
+
+# A valid database is tens of MB; bail before clobbering a good db with a bad one.
+if [ ! -s "$TMP_DB" ] || [ "$(stat -c '%s' "$TMP_DB")" -lt 1000000 ]; then
+  fail "Downloaded database looks invalid (smaller than 1 MB)."
+fi
+
+install -o root -g root -m 0644 "$TMP_DB" "$DB_PATH" || fail "Failed to install database to $DB_PATH."
+log "Installed refreshed database to $DB_PATH ($(stat -c '%s' "$DB_PATH") bytes)."
+
+systemctl restart alloy || fail "Failed to restart alloy."
+log "Alloy restarted with refreshed GeoIP database."
+
+hc_ping
+log "GeoIP database update completed successfully."

--- a/roles/base/templates/update-geoip-db.sh.j2
+++ b/roles/base/templates/update-geoip-db.sh.j2
@@ -11,7 +11,7 @@ set -uo pipefail
 DB_PATH="{{ base_alloy_geoip_db_path }}"
 DB_URL="{{ base_alloy_geoip_db_baseurl }}-$(date +%Y-%m).mmdb.gz"
 HC_URL="{{ base_alloy_geoip_hc_url }}{{ base_alloy_geoip_hc_uuid }}"
-HC_ENABLED="{{ 'true' if base_alloy_geoip_hc_uuid | default('') | length > 0 else 'false' }}"
+HC_ENABLED="{{ 'true' if (base_alloy_geoip_hc_uuid | default('') | length > 0) and (base_alloy_geoip_hc_url | default('') | length > 0) else 'false' }}"
 LOGFILE="/tmp/geoip_update_$(date +%Y-%m-%d).log"
 
 log() {

--- a/roles/base/templates/update-geoip-db.sh.j2
+++ b/roles/base/templates/update-geoip-db.sh.j2
@@ -42,12 +42,13 @@ gunzip -f "$TMP_GZ" || fail "Decompression failed."
 TMP_DB="${TMP_GZ%.gz}"
 
 # A valid database is tens of MB; bail before clobbering a good db with a bad one.
-if [ ! -s "$TMP_DB" ] || [ "$(stat -c '%s' "$TMP_DB")" -lt 1000000 ]; then
+DB_SIZE="$(stat -c '%s' "$TMP_DB" 2>/dev/null || echo 0)"
+if [ "$DB_SIZE" -lt 1000000 ]; then
   fail "Downloaded database looks invalid (smaller than 1 MB)."
 fi
 
 install -o root -g root -m 0644 "$TMP_DB" "$DB_PATH" || fail "Failed to install database to $DB_PATH."
-log "Installed refreshed database to $DB_PATH ($(stat -c '%s' "$DB_PATH") bytes)."
+log "Installed refreshed database to $DB_PATH ($DB_SIZE bytes)."
 
 systemctl restart alloy || fail "Failed to restart alloy."
 log "Alloy restarted with refreshed GeoIP database."

--- a/roles/docker/tasks/docker_application_setup.yaml
+++ b/roles/docker/tasks/docker_application_setup.yaml
@@ -10,3 +10,11 @@
     - docker
     - docker.compose
     - plex
+
+# Set up logrotate configs for Docker container log files
+- name: Set up logrotate configs
+  ansible.builtin.include_tasks: setup_logrotate.yaml
+  when: docker_logrotate_configs is defined
+  tags:
+    - docker
+    - docker.compose

--- a/roles/docker/tasks/setup_logrotate.yaml
+++ b/roles/docker/tasks/setup_logrotate.yaml
@@ -19,6 +19,5 @@
   loop: "{{ docker_logrotate_configs }}"
   loop_control:
     label: "{{ item.name }}"
-  when: docker_logrotate_configs is defined
   tags:
     - docker

--- a/roles/docker/tasks/setup_logrotate.yaml
+++ b/roles/docker/tasks/setup_logrotate.yaml
@@ -2,6 +2,14 @@
 # Set up logrotate configs for Docker container log files.
 # Input: docker_logrotate_configs (list of logrotate config entries)
 
+- name: Install logrotate
+  ansible.builtin.apt:
+    name: logrotate
+    state: present
+  become: true
+  tags:
+    - docker
+
 - name: Set up logrotate configs for Docker containers
   community.general.logrotate:
     name: "{{ item.name }}"

--- a/roles/docker/tasks/setup_logrotate.yaml
+++ b/roles/docker/tasks/setup_logrotate.yaml
@@ -1,0 +1,24 @@
+---
+# Set up logrotate configs for Docker container log files.
+# Input: docker_logrotate_configs (list of logrotate config entries)
+
+- name: Set up logrotate configs for Docker containers
+  community.general.logrotate:
+    name: "{{ item.name }}"
+    paths: "{{ item.paths }}"
+    rotation_period: "{{ item.rotation_period | default(omit) }}"
+    rotate_count: "{{ item.rotate_count | default(omit) }}"
+    size: "{{ item.size | default(omit) }}"
+    compress: "{{ item.compress | default(omit) }}"
+    delay_compress: "{{ item.delay_compress | default(omit) }}"
+    missing_ok: "{{ item.missing_ok | default(omit) }}"
+    not_if_empty: "{{ item.not_if_empty | default(omit) }}"
+    copy_truncate: "{{ item.copy_truncate | default(omit) }}"
+    state: present
+  become: true
+  loop: "{{ docker_logrotate_configs }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: docker_logrotate_configs is defined
+  tags:
+    - docker


### PR DESCRIPTION
Closes #155.

Implements Traefik access-log management and centralized logging: access-log filtering + rotation, a Loki/Alloy logging pipeline, GeoIP enrichment, and a set of Grafana dashboards (the "visualizer").

## What's included

**Traefik access logs**
- accessLog filters (drop sub-10ms health-check pings, keep retries) + `bufferingSize` on prod/prod-no-file-provider/dev configs
- Daily logrotate of `access.log` (14 rotations, 100 MB cap, `copytruncate`) via a new generic `docker` role task driven by `docker_logrotate_configs`

**Centralized logging (Loki + Alloy)**
- **Loki** container on docker-02 (single-binary, filesystem, 30-day retention), exposed at `loki.home.stechsolutions.ca` behind Traefik with an IP allowlist (Tailscale + RFC1918); auto-provisioned Grafana datasource + Pi-hole CNAME
- **Grafana Alloy** installed host-level via the base role (mirrors the node_exporter pattern; Grafana apt repo via the keyring + `signed-by` idiom). Runs as its packaged low-privilege `alloy` user. Log sources are data-driven via `base_alloy_log_sources`; ships the Traefik `access.log` to Loki

**GeoIP enrichment**
- Alloy `stage.geoip` enriches the client IP using the DB-IP City Lite database (MaxMind-compatible, no account). `geoip_country_code` is a label; high-cardinality fields (city, lat/lon, country name, client IP) are structured metadata
- A templated `update-geoip-db.sh` refreshes the DB monthly via root cron — sanity-checks the download, atomically installs, restarts Alloy, and pings Healthchecks (start/success/fail). A matching monthly HC check (31d timeout + 2d grace) is provisioned. Enabled on the public-facing docker-cloud-01

**Grafana dashboards** (provisioned v1, grouped in `dashboards_json/traefik/`)
- **Access Logs** — rate, status/method distribution, p50/p95/p99 latency, top hosts/paths, raw log view
- **Official Traefik (metrics)** — fixed `rate()` windows (`$__rate_interval`) so panels render with a ~1m scrape; moved into the traefik folder
- **Geo** — city-level coordinate map (fit-to-data, clickable markers that drill into that city's logs in Explore), top countries, request rate by country, top external client IPs with city + country name
- **Intranet** — internal-client traffic (RFC1918 + Tailscale, backtick-regex on `ClientHost`): top clients/hosts, status rate + distribution, internal access log

## Notes
- `community.general` pinned to `>=12.5.0` (logrotate module)
- Docs updated (CLAUDE.md monitoring/logging section, `base.alloy` tag, MANUAL_CONFIG Loki datasource note)
- Ran `/security-review` (no findings) and `/simplify` (applied) on the changes
- Follow-up tracked in #191: the docker config-file sync is additive (renamed/removed files linger on hosts); making it delete-aware needs care to avoid wiping runtime `data/` dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
