### PR TITLE
Bump ZFS scrub alert threshold from 30 to 37 days

### DIFF
--- a/files/prometheus/rules/storage_alerts.yaml
+++ b/files/prometheus/rules/storage_alerts.yaml
@@ -97,13 +97,13 @@ groups:
 
       # ZFS scrub and vdev error alerts — uses zpool_scrub_age_seconds/zpool_*_errors from textfile collector (zpool_metrics.sh)
       - alert: ZfsPoolScrubOverdue
-        expr: (zpool_scrub_age_seconds > 2592000) or (zpool_scrub_age_seconds == -1)
+        expr: (zpool_scrub_age_seconds > 3196800) or (zpool_scrub_age_seconds == -1)
         for: 5m
         labels:
           severity: warning
         annotations:
           summary: "ZFS pool scrub overdue (instance {{ $labels.instance }})"
-          description: "ZFS pool {{ $labels.pool }} on {{ $labels.instance }} has not been scrubbed in over 30 days (or never). Run 'zpool scrub {{ $labels.pool }}'.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: "ZFS pool {{ $labels.pool }} on {{ $labels.instance }} has not been scrubbed in over 37 days (or never). Run 'zpool scrub {{ $labels.pool }}'.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
       - alert: ZfsPoolChecksumErrors
         expr: zpool_checksum_errors > 0


### PR DESCRIPTION
## Summary

- `zfsutils-linux` schedules ZFS scrubs on the second Sunday of each month, creating a worst-case ~35-day gap between consecutive scrubs
- The previous 30-day threshold caused spurious alerts every month in the days before the next scrub ran
- 37 days gives a comfortable buffer above the 35-day worst case

## Test plan
- [ ] Verify alerts clear after June 14 scrub runs (or deploy Prometheus config and confirm alert is no longer firing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)