### PR TITLE
Add ffmpeg to storage VM base packages

### DIFF
--- a/inventories/home/host_vars/storage.home.stechsolutions.ca.yaml
+++ b/inventories/home/host_vars/storage.home.stechsolutions.ca.yaml
@@ -9,6 +9,7 @@ base_node_exporter_zfs_collector: true
 
 base_host_additional_packages:
   - unrar
+  - ffmpeg
 
 fileserver_setup: true
 fileserver_setup_mergerfs: false


### PR DESCRIPTION
## Summary

- Adds `ffmpeg` to `base_host_additional_packages` on the storage VM to codify a manually installed package and prevent drift

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)