### PR TITLE
Add pipx and pipx packages to workstations

### DIFF
--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -80,6 +80,17 @@ ansible-playbook playbooks/hosts_configure.yaml --tags=fileserver
 - `fileserver.nfs-server` - Configure NFS server
 - `fileserver.nfs-client` - Configure NFS client mounts
 
+## Workstation Tags
+
+Configure workstations (desktops, laptops, WSL). Used with `playbooks/workstations.yaml`.
+
+```bash
+ansible-playbook playbooks/workstations.yaml --limit=$(hostname) --tags=workstation
+```
+
+- `workstation` - All workstation-specific tasks
+- `workstation.pipx` - Install pipx packages defined in `workstation_pipx_packages`
+
 ## Additional Service Tags
 
 - `healthchecks` - Configure Healthchecks.io monitoring

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -50,6 +50,21 @@ Update dotfiles on all hosts:
 ansible-playbook playbooks/dotfiles_update.yaml
 ```
 
+### Workstations
+Configure workstations (desktops, laptops, WSL). Must be run one host at a time:
+
+```bash
+source scripts/select-inventory.sh workstations
+ansible-playbook playbooks/workstations.yaml --limit=$(hostname)
+```
+
+Run only pipx package installation:
+```bash
+ansible-playbook playbooks/workstations.yaml --limit=$(hostname) --tags=workstation.pipx
+```
+
+Pipx packages are defined in `inventories/workstations/group_vars/all/main.yaml` under `workstation_pipx_packages`.
+
 ### Service-Specific Playbooks
 Configure services managed through dedicated playbooks:
 

--- a/inventories/workstations/group_vars/all/main.yaml
+++ b/inventories/workstations/group_vars/all/main.yaml
@@ -22,7 +22,17 @@ base_packages:
 
 # Desktop-specific additional packages
 base_group_additional_packages:
+  - pipx
   - qrencode
+
+workstation_pipx_packages:
+  - name: ansible-core
+  - name: ansible-lint
+  - name: asciinema
+  - name: pipenv
+  - name: python-kasa
+  - name: ruff
+  - name: yamllint
 
 base_users:
   - name: "{{ default_user }}"

--- a/playbooks/workstations.yaml
+++ b/playbooks/workstations.yaml
@@ -2,6 +2,10 @@
 # Playbook for configuring workstations (desktops, laptops, WSL)
 # Run with: ansible-playbook playbooks/workstations.yaml
 # Select inventory first: source scripts/select-inventory.sh workstations
+#
+# Variables (defined in inventories/workstations/group_vars/all/main.yaml):
+#   workstation_pipx_packages: list of pipx apps to install for default_user
+#     each entry: { name: <package> }
 
 - name: Configure workstations
   hosts: all
@@ -15,7 +19,7 @@
       ansible.builtin.assert:
         that:
           - ansible_play_hosts | length == 1
-          - inventory_hostname == ansible_hostname
+          - inventory_hostname == ansible_facts["hostname"]
         fail_msg: >
           WSL hosts use ansible_connection=local and must be targeted individually.
           Run with: ansible-playbook playbooks/workstations.yaml --limit=$(hostname)
@@ -32,3 +36,21 @@
         - base.dotfiles
         - base.timezone
         - base.user
+
+    # TODO: migrate to community.general.pipx with state: latest once workstations
+    # are on Ubuntu 26.04 (ships pipx 1.8, meets module's 1.7.0 minimum).
+    # See https://github.com/nstoik/infrastructure/issues/203
+    - name: Install pipx packages
+      ansible.builtin.command:
+        cmd: "pipx install {{ item.name }}"
+      loop: "{{ workstation_pipx_packages }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: pipx_result
+      changed_when: pipx_result.rc == 0
+      failed_when: pipx_result.rc != 0 and 'already seems to be installed' not in pipx_result.stdout
+      become: true
+      become_user: "{{ default_user }}"
+      tags:
+        - workstation
+        - workstation.pipx

--- a/playbooks/workstations.yaml
+++ b/playbooks/workstations.yaml
@@ -47,7 +47,7 @@
       loop_control:
         label: "{{ item.name }}"
       register: pipx_result
-      changed_when: pipx_result.rc == 0
+      changed_when: "'already seems to be installed' not in pipx_result.stdout"
       failed_when: pipx_result.rc != 0 and 'already seems to be installed' not in pipx_result.stdout
       become: true
       become_user: "{{ default_user }}"


### PR DESCRIPTION
## Summary

- Installs `pipx` via apt on workstation hosts
- Defines `workstation_pipx_packages` in workstations group_vars with: `ansible-core`, `ansible-lint`, `asciinema`, `pipenv`, `python-kasa`, `ruff`, `yamllint`
- Adds `Install pipx packages` task to `playbooks/workstations.yaml` tagged `workstation.pipx`
- Fixes deprecation warning: `ansible_hostname` → `ansible_facts["hostname"]`
- Adds workstation docs to `docs/USAGE.md` and `docs/TAGS.md`

Uses `ansible.builtin.command` as a workaround since Ubuntu 24.04 ships pipx 1.4.3 and `community.general.pipx` requires >= 1.7.0. Tracked in #203 for migration once workstations move to Ubuntu 26.04.

## Test plan

- [x] Run `ansible-playbook playbooks/workstations.yaml --limit=$(hostname) --tags=workstation.pipx` on a workstation host
- [x] Verify all pipx packages are installed (`pipx list`)
- [x] Re-run and confirm task reports `ok` (not `changed`) for already-installed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)