### PR TITLE
Add patchutils to workstation packages

### DIFF
--- a/inventories/workstations/group_vars/all/main.yaml
+++ b/inventories/workstations/group_vars/all/main.yaml
@@ -22,6 +22,7 @@ base_packages:
 
 # Desktop-specific additional packages
 base_group_additional_packages:
+  - patchutils
   - pipx
   - qrencode
 


### PR DESCRIPTION
## Summary
- Adds `patchutils` to `base_group_additional_packages` in the workstations group_vars

## Why
`patchutils` provides `filterdiff`, used by `pr-review.sh` to exclude files (e.g. large JSON dashboards) from PR diffs before sending to Ollama for review.

Closes #209

## Test plan
- [x] `ansible-playbook playbooks/workstations.yaml --limit=$(hostname) --tags=base.apt` installs `patchutils`
- [x] `filterdiff --help` works after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)