### PR TITLE
Add Plex Direct Connect Relay via VPS (temporary CGNAT workaround)

### DIFF
--- a/docs/services/cloud_hosts.md
+++ b/docs/services/cloud_hosts.md
@@ -14,3 +14,56 @@ ansible-playbook playbooks/cloud_hosts/create_host.yaml
 This calls the create_droplet file for each droplet specified. It also creates any block storage volumes specified in the configuration file.
 
 The second half of the [create_host.yaml](../../playbooks/cloud_hosts/create_host.yaml) runs against all DigitalOcean droplets to create the user if neeeded. Since root login is disabled afterwards, this skips the user creation if the host is unreachable via the root user. If the play is run 5 times within 10 minutes, fail2ban will ban the IP address (probably the local machine). You can unban the IP by logging in through the web console and running `fail2ban-client set sshd unbanip <ip>`.
+
+## DigitalOcean Firewalls
+
+Firewalls are tag-based and defined in [roles/digitalocean/vars/main.yml](../../roles/digitalocean/vars/main.yml) (`digitalocean_tags`, `digitalocean_firewall`). A droplet only receives a firewall's inbound rules if it carries the matching tag in its `tags:` list in [droplet.yaml](../../playbooks/cloud_hosts/vars/droplet.yaml). Apply changes with:
+
+```bash
+ansible-playbook playbooks/digitalocean.yaml --tags digitalocean.tags,digitalocean.firewall
+```
+
+Tagging/untagging a droplet (after editing `droplet.yaml`) is applied with:
+
+```bash
+ansible-playbook playbooks/cloud_hosts/create_host.yaml --tags digitalocean.droplet
+```
+
+## Plex Direct Connect Relay (temporary, CGNAT workaround)
+
+**Why this exists:** the Proxmox server (and `docker-01`, which runs Plex) was temporarily relocated to a network behind Starlink, which uses CGNAT. CGNAT means the router no longer has a unique public IP, so the previous approach — forwarding port `32400` on the home router — no longer has any effect (see the [Plex section](./media.md#plex) for the normal, non-CGNAT setup).
+
+**How it works:** `docker-01` was never enrolled in Tailscale directly. Instead, this relies on the existing home subnet router (`vpn.home.stechsolutions.ca`, host_vars at `inventories/home/host_vars/vpn.home.stechsolutions.ca.yaml`) which advertises `10.10.1.0/24,10.10.5.0/24` over Tailscale, and `docker-cloud-01` which already runs with `--accept-routes`. Since Tailscale tunnels are outbound-initiated, this keeps working through CGNAT without any inbound port-forward at the home network's edge.
+
+`docker-cloud-01`'s Traefik instance terminates the public connection and forwards it over that existing Tailscale path. Everything is gated behind a single flag, `plex_relay_enabled`, set in `inventories/home/host_vars/docker-cloud-01/docker.yaml`:
+
+- `files/traefik/traefik-prod.yaml.j2` — declares the `plex` entryPoint on `:32400` only `{% if plex_relay_enabled %}`. This file is shared with `docker-02`, which never sets the flag, so it never gets this entryPoint (`default(false)`).
+- `files/traefik/dynamic/plex.yaml.j2` — TCP router/service (`HostSNI(\`*\`)` passthrough, no TLS) forwarding to `docker-01.home.stechsolutions.ca:32400`, also wrapped in the same `{% if plex_relay_enabled %}` guard.
+- `inventories/home/host_vars/docker-cloud-01/docker_compose/proxy.yaml.j2` — publishes `32400:32400` on the Traefik container, same guard. This is the real kill switch: without the host port published, nothing listens on 32400 at all, regardless of the DO firewall or Traefik's internal router.
+- `roles/digitalocean/vars/main.yml` / `playbooks/cloud_hosts/vars/droplet.yaml` — add the `Plex` tag and `StechSolutions-Plex` firewall (inbound TCP 32400 from anywhere), and tag `docker-cloud-01` with it permanently, the same way `HTTPS` and `SSH` are always-on. The firewall being open with nothing listening behind it is a no-op, so this doesn't need to track the flag.
+
+### Toggling on/off
+
+Flip `plex_relay_enabled` in `inventories/home/host_vars/docker-cloud-01/docker.yaml`, then apply it:
+
+```bash
+ansible-playbook playbooks/docker_compose.yaml --limit docker-cloud-01
+```
+
+Setting it to `false` and running this un-publishes port 32400 and removes the Traefik entrypoint/router content — equivalent to the manual revert steps below, without editing multiple files by hand.
+
+**Plex-side manual config:** Settings → Network → Custom server access URLs → `http://<docker-cloud-01 public IP>:32400`. This is required because Plex can't auto-detect a port mapping that lives on a separate VPS.
+
+**Verifying it's working:** from a machine that is *not* using a Tailscale exit node (otherwise the request may loop through the tailnet instead of testing the real public path):
+
+```bash
+curl http://<docker-cloud-01 public IP>:32400/identity
+```
+
+A `200` response with an XML `MediaContainer` body containing your Plex server's `machineIdentifier` confirms the DO firewall, Traefik TCP router, and the Tailscale hop back to `docker-01` are all working. On a remote client, check the connection details show "Direct" rather than "Relayed".
+
+**Reverting once the server moves back home:**
+
+1. Set `plex_relay_enabled: false` in `inventories/home/host_vars/docker-cloud-01/docker.yaml` and run the command from [Toggling on/off](#toggling-onoff) above. This un-publishes port 32400 and removes the Traefik entrypoint/router — no need to delete the firewall or tag definitions.
+2. In Plex, clear Settings → Network → Custom server access URLs.
+3. Re-enable the port forward (`32400` -> `docker-01`) on the home router, now that it has a routable public IP again.

--- a/docs/services/media.md
+++ b/docs/services/media.md
@@ -144,6 +144,7 @@ Ombi is configured via its web interface.
 ### Plex
 - Docker: expose port `32400` (eg. `-p 32400:32400/tcp`).
 - Router: forward TCP `32400` (or chosen external port) -> `<PLEX_HOST_IP>:32400`.
+  - Only works when the home network has a real public IP. If it's behind CGNAT (eg. Starlink), see [Plex Direct Connect Relay](./cloud_hosts.md#plex-direct-connect-relay-temporary-cgnat-workaround) for the VPS-forwarding workaround.
 - Claim: set `PLEX_CLAIM` env var for first-boot server claim if needed.
 - Plex UI: Settings → Server → Remote Access — enable manual port if not auto, enter external port, then retry until green.
 - Integrations: configure Tautulli and Ombi to point to the Plex server and use API keys stored in the Vault.

--- a/files/traefik/dynamic/plex.yaml.j2
+++ b/files/traefik/dynamic/plex.yaml.j2
@@ -1,0 +1,15 @@
+---
+{% if plex_relay_enabled | default(false) %}
+tcp:
+  routers:
+    plex-router:
+      rule: HostSNI(`*`)
+      entryPoints:
+        - plex
+      service: plex-service
+  services:
+    plex-service:
+      loadBalancer:
+        servers:
+          - address: docker-01.home.stechsolutions.ca:32400
+{% endif %}

--- a/files/traefik/traefik-prod.yaml.j2
+++ b/files/traefik/traefik-prod.yaml.j2
@@ -15,6 +15,12 @@ entryPoints:
     address: ":443"
   metrics:
     address: ":8081"
+{% if plex_relay_enabled | default(false) %}
+  # TCP passthrough for the Plex Direct Connect Relay (docker-cloud-01 only).
+  # See docs/services/cloud_hosts.md#plex-direct-connect-relay-temporary-cgnat-workaround
+  plex:
+    address: ":32400"
+{% endif %}
 
 accessLog:
   filepath: /etc/traefik/access.log

--- a/inventories/home/host_vars/docker-02.home.stechsolutions.ca/docker.yaml
+++ b/inventories/home/host_vars/docker-02.home.stechsolutions.ca/docker.yaml
@@ -58,7 +58,7 @@ docker_configuration_paths:
 docker_configuration_files:
   # traefik configuration file
   - name: traefik.yaml
-    src: "{{ inventory_dir }}/../../files/traefik/traefik-prod.yaml"
+    src: "{{ inventory_dir }}/../../files/traefik/traefik-prod.yaml.j2"
     dest: /home/{{ default_user }}/docker_mounts/proxy/traefik/traefik.yaml
     mode: '0664'
     container_name: traefik

--- a/inventories/home/host_vars/docker-cloud-01/docker.yaml
+++ b/inventories/home/host_vars/docker-cloud-01/docker.yaml
@@ -1,6 +1,12 @@
 ---
 # Host variables for docker-cloud-01 host.
 
+# Toggles the Plex Direct Connect Relay (temporary CGNAT workaround).
+# See docs/services/cloud_hosts.md#plex-direct-connect-relay-temporary-cgnat-workaround
+# Single flag: gates the Traefik :32400 entryPoint, the plex.yaml dynamic
+# router config, and the compose port publish below.
+plex_relay_enabled: true
+
 docker_logrotate_configs:
   - name: traefik
     paths:
@@ -26,13 +32,18 @@ docker_configuration_paths:
 docker_configuration_files:
   # traefik configuration file
   - name: traefik.yaml
-    src: "{{ inventory_dir }}/../../files/traefik/traefik-prod.yaml"
+    src: "{{ inventory_dir }}/../../files/traefik/traefik-prod.yaml.j2"
     dest: /home/{{ default_user }}/docker_mounts/proxy/traefik/traefik.yaml
     mode: '0664'
     container_name: traefik
   - name: media_homepage.yaml
     src: "{{ inventory_dir }}/../../files/traefik/dynamic/media_homepage.yaml"
     dest: /home/{{ default_user }}/docker_mounts/proxy/traefik/dynamic/media_homepage.yaml
+    mode: '0664'
+    container_name: traefik
+  - name: plex.yaml
+    src: "{{ inventory_dir }}/../../files/traefik/dynamic/plex.yaml.j2"
+    dest: /home/{{ default_user }}/docker_mounts/proxy/traefik/dynamic/plex.yaml
     mode: '0664'
     container_name: traefik
   # ntfy configuration file

--- a/inventories/home/host_vars/docker-cloud-01/docker_compose/proxy.yaml.j2
+++ b/inventories/home/host_vars/docker-cloud-01/docker_compose/proxy.yaml.j2
@@ -18,6 +18,9 @@ services:
         - "80:80"
         - "443:443"
         - "8081:8081"
+{% if plex_relay_enabled | default(false) %}
+        - "32400:32400"
+{% endif %}
     depends_on:
         - docker-socket-proxy
     healthcheck:

--- a/playbooks/cloud_hosts/vars/droplet.yaml
+++ b/playbooks/cloud_hosts/vars/droplet.yaml
@@ -32,7 +32,7 @@ cloud_droplets:
     size: 's-1vcpu-1gb'
     region: 'tor1'
     image: 'ubuntu-24-04-x64'
-    tags: ['HTTPS', 'Docker']
+    tags: ['HTTPS', 'Docker', 'Plex']
     cf_records:
       - name: 'docker-cloud-01'
         zone: 'stechsolutions.ca'

--- a/roles/digitalocean/vars/main.yml
+++ b/roles/digitalocean/vars/main.yml
@@ -21,6 +21,8 @@ digitalocean_tags:
     state: "present"
   - name: "Docker"
     state: "present"
+  - name: "Plex"
+    state: "present"
 
 # Tags that are added to all DigitalOcean Droplets managed by Ansible.
 digitalocean_default_tags:
@@ -82,6 +84,14 @@ digitalocean_firewall:
         sources:
           addresses: ["0.0.0.0/0", "::/0"]
       - ports: "80"
+        protocol: "tcp"
+        sources:
+          addresses: ["0.0.0.0/0", "::/0"]
+  - name: "StechSolutions-Plex"
+    state: "present"
+    tags: ["Plex"]
+    inbound_rules:
+      - ports: "32400"
         protocol: "tcp"
         sources:
           addresses: ["0.0.0.0/0", "::/0"]


### PR DESCRIPTION
## Summary
- The Proxmox server (and `docker-01`, which runs Plex) is temporarily behind Starlink CGNAT, so the previous home-router port-forward for 32400 no longer has any effect.
- `docker-cloud-01` already has a working Tailscale path to `docker-01` via the existing home subnet router, so Traefik on `docker-cloud-01` now terminates the public connection on a new `:32400` entryPoint and forwards it there as raw TCP passthrough.
- Everything is gated behind a single `plex_relay_enabled` flag (`inventories/home/host_vars/docker-cloud-01/docker.yaml`) — it drives the Traefik entryPoint, the dynamic TCP router, and the compose port publish (the real kill switch) all through the same `.j2` template mechanism the docker role already supports.
- DigitalOcean firewall/tag for port 32400 added following the existing `StechSolutions-HTTPS`/`-SSH` tag-based pattern; left always-attached since an open port with nothing listening is a no-op.
- Docs added to `docs/services/cloud_hosts.md` (why/how/toggle/revert/verify) and cross-linked from `docs/services/media.md`.

## Test plan
- [x] `yamllint .` and `ansible-playbook --syntax-check` pass
- [x] Verified both new `.j2` templates render to valid YAML in both flag states (rendered locally with Jinja, confirmed `entryPoints` gains/loses the `plex` key correctly, confirmed `docker-02` — which never sets the flag — never gets the entrypoint)
- [x] Deployed and verified end-to-end against the real VPS: `curl http://<public-ip>:32400/identity` returned `HTTP 200` with the real Plex `machineIdentifier`
- [x] Ran `/security-review` — no findings above the confidence bar
- [x] Ran `/simplify` — 4 parallel review agents (reuse/simplification/efficiency/altitude), applied fixes: removed a cross-playbook `hostvars` coupling, removed the shared `traefik-prod.yaml` polluting unrelated host `docker-02`, gated the previously-ungated config file copy, renamed the flag away from the `_setup` role-gate convention
- [ ] Plex UI manual step still needed post-merge/deploy: Settings → Network → Custom server access URLs → VPS public IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)